### PR TITLE
Quiet the call to wp-cli cache flush

### DIFF
--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -145,7 +145,7 @@ class WpcliDriver extends BaseDriver
      */
     public function clearCache()
     {
-        $this->wpcli('cache', 'flush');
+        $this->wpcli('cache', 'flush', ["--quiet"]);
     }
 
     /**


### PR DESCRIPTION
While running behat with this extension I was getting `UnexpectedValueException` exceptions due to the cache flush outputting a success message. The exception caused behat to return an error code 1, despite successfully passing the Behat tests.

This pull request adds the `--quiet` argument to the call to WP-CLI's cache flush.

Here's the sample output before the command was quieted:

```
Feature: As a visitor I should be able to load the home page

  Scenario: Home page loads    # features/homepage.feature:3
    Given I am on the homepage # Behat\MinkExtension\Context\MinkContext::iAmOnHomepage()
    Then I should see "Sites"  # Behat\MinkExtension\Context\MinkContext::assertPageContainsText()
  │
  ╳  WP-CLI driver query failure: Success: The cache was flushed. (UnexpectedValueException)
  │
  └─ @AfterScenario # PaulGibbs\WordpressBehatExtension\Context\WordpressContext::clearCache()

1 scenario (1 passed)
2 steps (2 passed)
0m1.90s (11.83Mb)
Script vendor/bin/behat --config=build/behat/behat.yml --colors handling the test-behat event returned with error code 1
```

And here's the output after:

```
Feature: As a visitor I should be able to load the home page

  Scenario: Home page loads    # features/homepage.feature:3
    Given I am on the homepage # Behat\MinkExtension\Context\MinkContext::iAmOnHomepage()
    Then I should see "Sites"  # Behat\MinkExtension\Context\MinkContext::assertPageContainsText()

1 scenario (1 passed)
2 steps (2 passed)
0m1.56s (11.83Mb)
```
