### PR TITLE
Use ROOT placeholder rather than hard-coded path.

### DIFF
--- a/bin/travis/default-site.tpl.conf
+++ b/bin/travis/default-site.tpl.conf
@@ -1,6 +1,6 @@
 server {
   server_name {SERVER};
-  root /home/travis/build/paulgibbs/behat-wordpress-extension/www;
+  root {ROOT};
 
   listen 127.0.0.1:8080;
   listen [::]:8080 default ipv6only=on;


### PR DESCRIPTION
Fixes nginx server not correctly set up on local copies.