### PR TITLE
If site_url is not present, default to mink's base_url

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -50,7 +50,7 @@ Option           | Default value | Description
 `path`           | null          | _Required_.<br>Path to WordPress files.
 `users.*`        | _see example_ | _Optional_.<br>Keys must match names of WordPress roles.
 `permalinks.*`   | _see example_ | _Optional_.<br>Permalink pattern for the specific kind of link.<br>`%s` is replaced with an ID/object name, as appropriate.
-`site_url`       | null          | _Optional_.<br>If your site's `home_url()` and `site_url()` values [mismatch](http://wordpress.stackexchange.com/a/50605),<br>set this to the `site_url()` value.
+`site_url`       | null          | _Optional_.<br>If your site's `home_url()` and `site_url()` values [mismatch](http://wordpress.stackexchange.com/a/50605),<br>set this to the `site_url()` value. Defaults to `mink.base_url`
 `wpcli.alias`    | null          | _Optional_.<br>[WP-CLI alias](https://wp-cli.org/commands/cli/alias/) (preferred over `wpcli.path`).
 
 

--- a/src/ServiceContainer/WordpressBehatExtension.php
+++ b/src/ServiceContainer/WordpressBehatExtension.php
@@ -79,7 +79,7 @@ class WordpressBehatExtension implements ExtensionInterface
                 ->scalarNode('path')->end()
 
                 // WordPress' "siteurl" option.
-                ->scalarNode('site_url')->end()
+                ->scalarNode('site_url')->defaultValue('%mink.base_url%')->end()
 
                 // Account roles -> username/password.
                 ->arrayNode('users')


### PR DESCRIPTION
## Description
When the `site_url` is not present in `behat.yml`, default to `mink.base_url`.

## Motivation and context
If a `site_url` is not provided in the config then accessing `wp-admin/` or `wp-login.php` won't work: https://github.com/paulgibbs/behat-wordpress-extension/blob/master/src/Context/RawWordpressContext.php#L53. A `site_url` is necessary when WordPress is not installed at the `base_url`, but otherwise we can just default to `base_url` so that the URL need not be duplicated in the `behat.yml`.

## How has this been tested?
Manually inspected. It will be covered by the test suite in a forthcoming PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
