### PR TITLE
typo fix in settings page's YML

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -31,7 +31,7 @@ PaulGibbs\WordpressBehatExtension:
       password: subscriber
 
   # WordPress settings.
-  siteurl: ~
+  site_url: ~
   permalinks:
     author_archive: author/%s/
 


### PR DESCRIPTION
s/siteurl/site_url

## Description
Very simple typo fix I noticed in the settings page's example YML file,
