### PR TITLE
Only decrypt publish-key when we are publishing to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,7 @@ before_install:
   # Execute all of the commands which need to be executed before installing dependencies.
 
   # Set up deploy key for docs.
-  - openssl aes-256-cbc -K $encrypted_a7d0b9fc4af0_key -iv $encrypted_a7d0b9fc4af0_iv -in bin/travis/publish-key.enc -out ~/.ssh/publish-key -d
-  - chmod u=rw,og= ~/.ssh/publish-key
-  - echo "Host github.com" >> ~/.ssh/config
-  - echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config
+  - if [[ "$TRAVIS_PULL_REQUEST" = "false" && "$WH_BUILD_DOCS" = "1" && "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PHP_VERSION" = "7.1" ]] ; then bin/travis/deploy-key.sh; fi
 
   # Set up Behat.
   - composer self-update

--- a/bin/travis/deploy-key.sh
+++ b/bin/travis/deploy-key.sh
@@ -1,0 +1,4 @@
+openssl aes-256-cbc -K $encrypted_a7d0b9fc4af0_key -iv $encrypted_a7d0b9fc4af0_iv -in bin/travis/publish-key.enc -out ~/.ssh/publish-key -d
+chmod u=rw,og= ~/.ssh/publish-key
+echo "Host github.com" >> ~/.ssh/config
+echo "  IdentityFile ~/.ssh/publish-key" >> ~/.ssh/config


### PR DESCRIPTION
## Description
Move script for preparing the publish key to its own file and wrap it inside a conditional in `.travis.yml`

## Motivation and context
The builds are failing on my copy as I don't have the decryption key.

## How has this been tested?
It hasn't, I can't :)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
