### PR TITLE
Supporting custom driver(s) via a behat.yml config

### DIFF
--- a/bin/travis/behat.yml
+++ b/bin/travis/behat.yml
@@ -26,6 +26,8 @@ default:
 
     PaulGibbs\WordpressBehatExtension:
       path: www
+      default_driver: custom
+      custom_driver: %paths.base%/drivers/custom.yml
       users:
         admin:
           username: admin

--- a/bin/travis/drivers/custom.yml
+++ b/bin/travis/drivers/custom.yml
@@ -1,0 +1,13 @@
+parameters:
+  wordpress.driver.custom.class: PaulGibbs\WordpressBehatExtension\Driver\CustomDriver
+
+services:
+  wordpress.driver.custom:
+    class: %wordpress.driver.custom.class%
+    arguments:
+      - %wordpress.driver.wpcli.alias%
+      - %wordpress.path%
+      - %mink.base_url%
+      - %wordpress.driver.wpcli.binary%
+    tags:
+      - { name: wordpress.driver, alias: custom }

--- a/src/Driver/CustomDriver.php
+++ b/src/Driver/CustomDriver.php
@@ -1,0 +1,13 @@
+<?php
+namespace PaulGibbs\WordpressBehatExtension\Driver;
+
+use RuntimeException;
+use UnexpectedValueException;
+
+/**
+ * Connect Behat to WordPress using WP-CLI.
+ */
+class CustomDriver extends WpcliDriver
+{
+
+}

--- a/src/ServiceContainer/WordpressBehatExtension.php
+++ b/src/ServiceContainer/WordpressBehatExtension.php
@@ -73,10 +73,8 @@ class WordpressBehatExtension implements ExtensionInterface
         $builder
             ->children()
                 // Common settings.
-                ->enumNode('default_driver')
-                    ->values(['wpcli', 'wpapi', 'blackbox'])
-                    ->defaultValue('wpcli')
-                ->end()
+                ->scalarNode('default_driver')->defaultValue('wpcli')->end()
+                ->scalarNode('custom_driver')->end()
                 ->scalarNode('path')->end()
 
                 // WordPress' "siteurl" option.
@@ -195,6 +193,11 @@ class WordpressBehatExtension implements ExtensionInterface
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/config'));
         $loader->load('services.yml');
+
+        if (isset($config['custom_driver'])) {
+            $file = $container->getParameterBag()->resolveValue($config['custom_driver']);
+            $loader->load($file);
+        }
 
         $container->setParameter('wordpress.wordpress.default_driver', $config['default_driver']);
         $container->setParameter('wordpress.path', $config['path']);


### PR DESCRIPTION
## Description
This demonstrates how we might be able to support custom drivers.

## Related issue

See #51. This PR also relates to the same problem that #41 was trying to solve. It may also impact on #21 (specifically, how do we make it easy to extend/modify a driver).

## Motivation and context
Typically in plug-ins / themes / client- sites there will be a need to create custom steps specific to that project. Behat supports this by allowing users to specific the contexts they wish to use. Invariably, however, those step implementations will be need to interact with WordPress in a way that the native drivers do not support. For example, a step may want to make use of a plug-in/theme function.

The desire is then to extend an existing driver, (or less likely provide an entirely new one) which accommodates those additional functions. Additionally it would be desirable to do so with minimal code (e.g. a `DriverInterface` implementation and a configuration file), and without the overhead of registering an additional Behat extension.

This PR aims to demonstrate such a solution. 

## How has this been tested?
Tests have been run locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
