### PR TITLE
Support absolute paths to SQL dumps

### DIFF
--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -374,7 +374,7 @@ class WpcliDriver extends BaseDriver
      */
     public function importDatabase($import_file)
     {
-        if (! in_array($import_file[0], [DIRECTORY_SEPARATOR, '~'])) {
+        if (! in_array($import_file[0], [DIRECTORY_SEPARATOR, '~'], true)) {
             $import_file = getcwd() . "/{$import_file}";
         }
         $this->wpcli('db', 'import', [$import_file]);

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -367,11 +367,16 @@ class WpcliDriver extends BaseDriver
     /**
      * Import WordPress database.
      *
-     * @param string $import_file Relative path and filename of SQL file to import.
+     * If $import_file begins with a directory separator or ~ it is treated as an absolute path.
+     * Otherwise, it is treated as relative to the current working directory.
+     *
+     * @param string $import_file Relative or absolute path and filename of SQL file to import.
      */
     public function importDatabase($import_file)
     {
-        $import_file = getcwd() . "/{$import_file}";
+        if (! in_array($import_file[0], [DIRECTORY_SEPARATOR, '~'])) {
+            $import_file = getcwd() . "/{$import_file}";
+        }
         $this->wpcli('db', 'import', [$import_file]);
     }
 


### PR DESCRIPTION
## Description
If the path to the SQL file to import begins with a directory separator or `~` it should be treated as an absolute path.

## Related issue
Fixes #56

## Motivation and context
To allow absolute file paths to be provided. This allows developers to read it from the `behat.yml`, using placeholders such as `%paths.base%` (which resolves to absolute paths).

It also makes importing a database possible when the WordPress install is hosted remotely. In that instance, the SQL dump is (often) on the remote machine, and not on the local machine.

## How has this been tested?

Yes, this patch is in use as part of a client project.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(There is actually a partial breaking change, if a relative path was provided with a leading directory separator. I'm not sure if such a file would have been successfully imported0.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
