### PR TITLE
Add more PHPCS rules.

### DIFF
--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -2,15 +2,64 @@
 <ruleset name="WordHat coding standards">
   <rule ref="PSR1" />
   <rule ref="PSR2" />
+
   <rule ref="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket">
     <severity>5</severity>
   </rule>
   <rule ref="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket">
     <severity>5</severity>
   </rule>
+
+  <!-- Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators. -->
   <rule ref="Squiz.Strings.ConcatenationSpacing">
     <properties>
       <property name="spacing" value="1"/>
+      <property name="ignoreNewlines" value="true"/>
     </properties>
   </rule>
+
+  <!-- If you're not evaluating anything in the string, use single quotes. -->
+  <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+  <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+      <severity>0</severity>
+  </rule>
+
+  <!-- Braces shall be used for all blocks. -->
+  <rule ref="Squiz.ControlStructures.ControlSignature" />
+
+  <!-- Never use shorthand PHP start tags. Always use full PHP tags. -->
+  <rule ref="Generic.PHP.DisallowShortOpenTag"/>
+  <rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
+
+  <!-- Remove trailing whitespace at the end of each line of code. -->
+  <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+
+  <!-- When type casting, do it like so: $foo = (boolean) $bar; -->
+  <rule ref="Generic.Formatting.SpaceAfterCast"/>
+  <rule ref="Squiz.WhiteSpace.CastSpacing" />
+
+  <!-- In general, readability is more important than cleverness or brevity. -->
+  <rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
+  <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+
+  <!-- No error control operator. -->
+  <rule ref="Generic.PHP.NoSilencedErrors" />
+
+  <!-- Discourage use of the backtick operator (execution of shell commands). -->
+  <rule ref="Generic.PHP.BacktickOperator"/>
+
+  <!-- Disallow size functions in loops. -->
+  <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops" />
+
+  <!-- Warns about code that can never been executed. -->
+  <rule ref="Squiz.PHP.NonExecutableCode"/>
+
+  <!-- Tests that the ++ operators are used when possible and not used when it makes the code confusing. -->
+  <rule ref="Squiz.Operators.IncrementDecrementUsage"/>
+
+  <!-- Checks to ensure that the logical operators 'and' and 'or' are not used. -->
+  <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+
+  <!-- Checks that duplicate arguments are not used in function declarations. -->
+  <rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
 </ruleset>

--- a/src/Driver/WpapiDriver.php
+++ b/src/Driver/WpapiDriver.php
@@ -213,7 +213,7 @@ class WpapiDriver extends BaseDriver
         $result = wp_delete_post($id, isset($args['force']));
 
         if (! $result) {
-            throw new UnexpectedValueException("WordPress API driver failed deleting content.");
+            throw new UnexpectedValueException('WordPress API driver failed deleting content.');
         }
     }
 
@@ -230,7 +230,7 @@ class WpapiDriver extends BaseDriver
         $comment_id = wp_new_comment($args);
 
         if (! $comment_id) {
-            throw new UnexpectedValueException("WordPress API driver failed creating a new comment.");
+            throw new UnexpectedValueException('WordPress API driver failed creating a new comment.');
         }
 
         return array('id' => $comment_id);
@@ -247,7 +247,7 @@ class WpapiDriver extends BaseDriver
         $result = wp_delete_comment($id, isset($args['force']));
 
         if (! $result) {
-            throw new UnexpectedValueException("WordPress API driver failed deleting a comment.");
+            throw new UnexpectedValueException('WordPress API driver failed deleting a comment.');
         }
     }
 
@@ -294,7 +294,7 @@ class WpapiDriver extends BaseDriver
         $result = wp_delete_user($id, $args);
 
         if (! $result) {
-            throw new UnexpectedValueException("WordPress API driver failed deleting user.");
+            throw new UnexpectedValueException('WordPress API driver failed deleting user.');
         }
     }
 


### PR DESCRIPTION
## Description
This PR adds more PHPCS rules to our existing ruleset. These add to the generic rules loaded by the PSR1 and PSR2 extensions. These new rules were taking from a review of the sniffs configured in the https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards project, and mostly try to prevent creative mis-use of certain PHP elements in edge cases.

## Motivation and context
Stops us having to code review trivial stuff.

## How has this been tested?
Ran it locally. It found one problem in the existing code base, which I fixed (via `phpcbf`, though I'm not sure if we want to auto-run that -- probably not).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.