### PR TITLE
Rework `login()` method

### DIFF
--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -153,10 +153,16 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
         }
 
         $this->visitPath('wp-login.php?redirect_to=' . urlencode($this->locatePath('/')));
-
         $page = $this->getSession()->getPage();
-        $page->fillField('user_login', $username);
-        $page->fillField('user_pass', $password);
+
+        $node = $page->findField('user_login');
+        $node->focus();
+        $node->setValue($username);
+
+        $node = $page->findField('user_pass');
+        $node->focus();
+        $node->setValue($password);
+
         $page->findButton('wp-submit')->click();
 
         if (! $this->loggedIn()) {


### PR DESCRIPTION
## Description
Try to fix a bug with Behat entering both user/password into username field
by explicitly setting focus on the fields before entering values.

## Related issue
See #47

## How has this been tested?
Tested only on Travis-CI (where we've been able to recreate the bug semi-reliably).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.