### PR TITLE
Installation instructions: Install as a development dependency

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ All the commands that follow are written to install from the root of your projec
 2) Tell [Composer](https://getcomposer.org/) to install WordHat. To do this conveniently, run:
 
 ```Shell
-php composer.phar require paulgibbs/behat-wordpress-extension="dev-master"
+php composer.phar require --dev paulgibbs/behat-wordpress-extension="dev-master"
 ```
 
 This will create a `composer.json` file for you, and download the extension.


### PR DESCRIPTION
The `--dev` flag should be added to the composer installation instructions so the library is only installed as a development dependency.

(Previous PR was incorrect. Yay for testing.)