### PR TITLE
Adds Toolbar object

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -1,0 +1,18 @@
+Feature: Logging in, Logging out
+
+  @javascript
+  Scenario: I can log-in and out
+    Given I am logged in as an admin
+    And I am on the Dashboard
+    Then I should see "Howdy"
+
+    Given I am an anonymous user
+    Then I should not see "Howdy"
+
+  Scenario: I can log-in and out (no-js)
+    Given I am logged in as an admin
+    And I am on the Dashboard
+    Then I should see "Howdy"
+
+    Given I am an anonymous user
+    Then I should not see "Howdy"

--- a/features/toolbar.feature
+++ b/features/toolbar.feature
@@ -1,0 +1,39 @@
+Feature: Toolbar
+
+  Background:
+    Given I am logged in as an admin
+    And I am on "/"
+
+  @javascript @insulated
+  Scenario: I can go to the support forums
+    When I follow the toolbar link "WordPress > Support Forums"
+    Then I should be on "https://wordpress.org/support/"
+
+  @javascript @insulated
+  Scenario: I can add a new page
+    When I follow the toolbar link "New > Page"
+    Then I should be on the "Add New Page" page
+
+  @javascript @insulated
+  Scenario: I can select a site
+    When I follow the toolbar link "wordpress.dev > Widgets"
+    Then I should be on the "Widgets" page
+
+  @javascript @insulated
+  Scenario: I can go to comments
+    When I follow the toolbar link "Comments"
+    Then I should be on the "Comments" page
+
+  @javascript @insulated
+  Scenario: I can go to edit my profile
+    When I follow the toolbar link "Howdy, admin > Edit My Profile"
+    Then I should be on the "Profile" page
+
+  @javascript @insulated
+  Scenario: I can search using the toolbar
+    When I search for "Hello World" in the toolbar
+    Then I should see "Search results"
+
+  @javascript @insulated
+  Scenario: I can a greeting in the toolbar
+    Then I should see "Howdy, admin" in the toolbar

--- a/src/Context/PageObjectContextTrait.php
+++ b/src/Context/PageObjectContextTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PaulGibbs\WordpressBehatExtension\Context;
+
+use Behat\Behat\Context\Context;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Factory as PageObjectFactory;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
+
+trait PageObjectContextTrait
+{
+    /**
+     * @var PageObjectFactory
+     */
+    private $pageObjectFactory = null;
+
+    /**
+         * Creates a page object from its name
+     * @param string $name The name of the page object e.g 'Admin page'
+     * @return Page
+     * @throws \RuntimeException
+     */
+    public function getPage($name)
+    {
+        if (null === $this->pageObjectFactory) {
+            throw new \RuntimeException('To create pages you need to pass a factory with setPageObjectFactory()');
+        }
+
+        return $this->pageObjectFactory->createPage($name);
+    }
+
+    /**
+         * Creates a page object element from its name
+     * @param string $name The name of the page object element e.g 'Toolbar'
+     * @return Element
+     * @throws \RuntimeException
+     */
+    public function getElement($name)
+    {
+        if (null === $this->pageObjectFactory) {
+            throw new \RuntimeException('To create elements you need to pass a factory with setPageObjectFactory()');
+        }
+
+        return $this->pageObjectFactory->createElement($name);
+    }
+
+    /**
+         * Sets the factory for creating page and element objects
+     * @param PageObjectFactory $pageObjectFactory
+     */
+    public function setPageObjectFactory(PageObjectFactory $pageObjectFactory)
+    {
+        $this->pageObjectFactory = $pageObjectFactory;
+    }
+
+    /**
+     * Returns the factory used for creating page and element objects
+     * @return PageObjectFactory
+     */
+    public function getPageObjectFactory()
+    {
+        if (null === $this->pageObjectFactory) {
+            throw new \RuntimeException(
+                'To access the page factory you need to pass it first with setPageObjectFactory()'#
+            );
+        }
+
+        return $this->pageObjectFactory;
+    }
+}

--- a/src/Context/PageObjectContextTrait.php
+++ b/src/Context/PageObjectContextTrait.php
@@ -12,7 +12,7 @@ trait PageObjectContextTrait
     /**
      * @var PageObjectFactory
      */
-    private $pageObjectFactory = null;
+    private $page_object_factory = null;
 
     /**
          * Creates a page object from its name
@@ -22,11 +22,11 @@ trait PageObjectContextTrait
      */
     public function getPage($name)
     {
-        if (null === $this->pageObjectFactory) {
+        if (null === $this->page_object_factory) {
             throw new \RuntimeException('To create pages you need to pass a factory with setPageObjectFactory()');
         }
 
-        return $this->pageObjectFactory->createPage($name);
+        return $this->page_object_factory->createPage($name);
     }
 
     /**
@@ -37,20 +37,20 @@ trait PageObjectContextTrait
      */
     public function getElement($name)
     {
-        if (null === $this->pageObjectFactory) {
+        if (null === $this->page_object_factory) {
             throw new \RuntimeException('To create elements you need to pass a factory with setPageObjectFactory()');
         }
 
-        return $this->pageObjectFactory->createElement($name);
+        return $this->page_object_factory->createElement($name);
     }
 
     /**
          * Sets the factory for creating page and element objects
-     * @param PageObjectFactory $pageObjectFactory
+     * @param PageObjectFactory $page_object_factory
      */
-    public function setPageObjectFactory(PageObjectFactory $pageObjectFactory)
+    public function setPageObjectFactory(PageObjectFactory $page_object_factory)
     {
-        $this->pageObjectFactory = $pageObjectFactory;
+        $this->page_object_factory = $page_object_factory;
     }
 
     /**
@@ -59,12 +59,12 @@ trait PageObjectContextTrait
      */
     public function getPageObjectFactory()
     {
-        if (null === $this->pageObjectFactory) {
+        if (null === $this->page_object_factory) {
             throw new \RuntimeException(
                 'To access the page factory you need to pass it first with setPageObjectFactory()'#
             );
         }
 
-        return $this->pageObjectFactory;
+        return $this->page_object_factory;
     }
 }

--- a/src/Context/PageObjectContextTrait.php
+++ b/src/Context/PageObjectContextTrait.php
@@ -15,7 +15,7 @@ trait PageObjectContextTrait
     private $page_object_factory = null;
 
     /**
-         * Creates a page object from its name
+     * Creates a page object from its name
      * @param string $name The name of the page object e.g 'Admin page'
      * @return Page
      * @throws \RuntimeException

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -9,13 +9,17 @@ use Behat\MinkExtension\Context\RawMinkContext;
 use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
 use PaulGibbs\WordpressBehatExtension\Util;
 
+use SensioLabs\Behat\PageObjectExtension\Context\PageObjectAware;
+
 /**
  * Base Behat context.
  *
  * Does not contain any step defintions.
  */
-class RawWordpressContext extends RawMinkContext implements WordpressAwareInterface, SnippetAcceptingContext
+class RawWordpressContext extends RawMinkContext implements WordpressAwareInterface, SnippetAcceptingContext, PageObjectAware
 {
+    use PageObjectContextTrait;
+
     /**
      * WordPress driver manager.
      *
@@ -175,28 +179,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function logOut()
     {
-        $has_toolbar = false;
-        $page        = $this->getSession()->getPage();
-
-        try {
-            $has_toolbar = $page->has('css', '#wp-admin-bar-logout');
-
-        // This may fail if the user has not loaded any site yet.
-        } catch (DriverException $e) {
-        }
-
-        // No toolbar? Go to wp-admin, and check again.
-        if (! $has_toolbar) {
-            $this->visitPath('wp-admin/');
-            $has_toolbar = $page->has('css', '#wp-admin-bar-logout');
-        }
-
-        // No toolbar? User must be anonymous.
-        if (! $has_toolbar) {
-            return;
-        }
-
-        $page->find('css', '#wp-admin-bar-logout a')->click();
+        $this->getElement('Toolbar')->logOut();
     }
 
     /**

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -5,6 +5,7 @@ use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\RawMinkContext;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 
 use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
 use PaulGibbs\WordpressBehatExtension\Util;
@@ -160,11 +161,19 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
         $page = $this->getSession()->getPage();
 
         $node = $page->findField('user_login');
-        $node->focus();
+        try {
+            $node->focus();
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for GoutteDriver but neither is it necessary
+        }
         $node->setValue($username);
 
         $node = $page->findField('user_pass');
-        $node->focus();
+        try {
+            $node->focus();
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for GoutteDriver but neither is it necessary
+        }
         $node->setValue($password);
 
         $page->findButton('wp-submit')->click();

--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -4,12 +4,16 @@ namespace PaulGibbs\WordpressBehatExtension\Context;
 use InvalidArgumentException;
 use Behat\Gherkin\Node\TableNode;
 use function PaulGibbs\WordpressBehatExtension\Util\is_wordpress_error;
+use SensioLabs\Behat\PageObjectExtension\Context\PageObjectAware;
+use Behat\Mink\Exception\ElementTextException;
 
 /**
  * Provides step definitions for a range of common tasks. Recommended for all test suites.
  */
-class WordpressContext extends RawWordpressContext
+class WordpressContext extends RawWordpressContext implements PageObjectAware
 {
+
+    use PageObjectContextTrait;
     /**
      * Clear object cache.
      *
@@ -46,5 +50,50 @@ class WordpressContext extends RawWordpressContext
     public function iAmOnDashboard()
     {
         $this->visitPath('wp-admin/');
+    }
+
+    /**
+     * Searches for a term using the toolbar search field
+     *
+     * Example: When I search for "Hello World" in the toolbar
+     *
+     * @When I search for :search in the toolbar
+     */
+    public function iSearchUsingTheToolbar($search)
+    {
+        $this->getElement('Toolbar')->search($search);
+    }
+
+    /**
+     * Clicks the specified link in the toolbar.
+     *
+     * Example: Then I should see "Howdy, admin" in the toolbar
+     *
+     * @Then I should see :text in the toolbar
+     */
+    public function iShouldSeeTextInToolbar($text)
+    {
+        $toolbar = $this->getElement('Toolbar');
+        $actual = $toolbar->getText();
+        $regex = '/' . preg_quote($text, '/') . '/ui';
+
+        if (! preg_match($regex, $actual)) {
+            $message = sprintf('The text "%s" was not found in the toolbar', $text);
+            throw new ElementTextException($message, $this->getSession()->getDriver(), $toolbar);
+        }
+    }
+
+    /**
+     * Clicks the specified link in the toolbar.
+     *
+     * Example: When I follow the toolbar link "New > Page"
+     * Example: When I follow the toolbar link "Updates"
+     * Example: When I follow the toolbar link "Howdy, admin > Edit My Profile"
+     *
+     * @When I follow the toolbar link :link
+     */
+    public function iFollowTheToolbarLink($link)
+    {
+        $this->getElement('Toolbar')->clickToolbarLink($link);
     }
 }

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -1,0 +1,166 @@
+<?php
+namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Behat\Mink\Exception\ExpectationException;
+use PaulGibbs\WordpressBehatExtension\Util;
+
+/**
+ * An Element representing the admin menu.
+ */
+class Toolbar extends Element
+{
+    /**
+     * @var array|string $selector
+     */
+    protected $selector = '#wpadminbar';
+
+    /**
+     * Click a specific item in the toolbar.
+     *
+     * Top-level items are identified by their link text (e.g. 'Comments' ).
+     * Second-level items are identified by their parent text and link text,
+     * delimited by a right angle bracket. E.g. New > Post.
+     *
+     * @param string $link The toolbar item to click.
+     * @throws ExpectationException If the menu item does not exist
+     */
+    public function clickToolbarLink($link)
+    {
+        $link_parts = array_map('trim', preg_split('/(?<!\\\\)>/', $link));
+        $click_node = false;
+
+        $first_level_items = $this->findAll('css', '.ab-top-menu > li');
+
+        foreach ($first_level_items as $first_level_item) {
+            if ($this->elementIsTargetLink($first_level_item, $link_parts[0])) {
+                if (count($link_parts) > 1) {
+                    $click_node = $this->getSubmenuLinkNode($first_level_item, $link_parts[1]);
+                } else {
+                    // We are clicking a top-level item:
+                    $click_node = $first_level_item->find('css', 'a');
+                }
+                break;
+            }
+        }
+
+        if (false === $click_node) {
+            throw new ExpectationException(
+                sprintf('Toolbar link "%s" could not be found', $link),
+                $this->getDriver()
+            );
+        }
+
+        $click_node->click();
+    }
+
+    /**
+     * Determines whether the link name refers to the given NodeElement.
+     *
+     * Some toolbar links do not have any visible text, so we handle those
+     * seperately. Otherwise we compoare the link text to the text of the
+     * element.
+     *
+     * @param NodeElement $element The element to check
+     * @param string $link_text The link (text) to check for
+     * @return bool True if $link_text refers to $element. False otherwise.
+     */
+    protected function elementIsTargetLink($element, $link_text)
+    {
+        $current_item_name = strtolower($element->find('css', '.ab-item')->getText());
+
+        switch (strtolower($link_text)) :
+            case 'wordpress':
+                $is_link = $element->getAttribute('id') === 'wp-admin-bar-wp-logo';
+                break;
+            case 'updates':
+                $is_link = $element->getAttribute('id') === 'wp-admin-bar-updates';
+                break;
+            case 'comments':
+                $is_link = $element->getAttribute('id') === 'wp-admin-bar-comments';
+                break;
+            default:
+                $is_link = strtolower($link_text) === $current_item_name;
+        endswitch;
+
+        return $is_link;
+    }
+
+    /**
+     * Retruns a second-level toolbar NodeElement corresponding to the link text
+     * under the given first-level toolbar NodeElement.
+     *
+     * @param NodeElement $first_level_item The element to check under
+     * @param string $link_text The link (text) to check for
+     * @return NodeElement|null
+     */
+    protected function getSubmenuLinkNode($first_level_item, $link_text)
+    {
+        $second_level_items = $first_level_item->findAll('css', 'ul li a');
+        $submenu_link_node = null;
+        foreach ($second_level_items as $second_level_item) {
+            $current_item_name = Util\stripTagsAndContent($second_level_item->getHtml());
+            if (strtolower($link_text) === strtolower($current_item_name)) {
+                try {
+                    // "Focus" (add hover class) on the toolbar link so the submenu appears
+                    $id = $first_level_item->getAttribute('id');
+                    $this->getDriver()->evaluateScript(
+                        'jQuery( "#' . $id . '" ).addClass("hover");'
+                    );
+                } catch (UnsupportedDriverActionException $e) {
+                    // This will fail for GoutteDriver but neither is it necessary
+                }
+                $submenu_link_node = $second_level_item;
+                break;
+            }
+        }
+        return $submenu_link_node;
+    }
+
+    /**
+     * Searches for the given text using the toolbar search field.
+     *
+     * @param string $text Text to enter into the search field
+     */
+    public function search($text)
+    {
+        $search = $this->find('css', '#adminbarsearch');
+
+        if (! $search) {
+            throw new ExpectationException(
+                'Search field in the toolbar could not be found',
+                $this->getDriver()
+            );
+        }
+
+        try {
+            $search->find('css', '#adminbar-search')->press();
+            $search->find('css', '#adminbar-search')->focus();
+            $search->fillField('adminbar-search', $text);
+            $search->find('css', '#adminbar-search')->focus();
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for GoutteDriver but neither is it necessary
+            $search->fillField('adminbar-search', $text);
+        }
+
+        $search->submit();
+    }
+
+    /**
+     * Logs-out using the toolbar log-out link.
+     */
+    public function logOut()
+    {
+        // Using NodeElement::mouseOver() won't work because WordPress is using hoverIndent. Instead we just
+        // manually add the hover class. See https://github.com/paulgibbs/behat-wordpress-extension/issues/65
+        try {
+            $this->getDriver()->evaluateScript(
+                'jQuery( "#wp-admin-bar-my-account" ).addClass("hover");'
+            );
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for GoutteDriver but neither is it necessary
+        }
+        $this->find('css', '#wp-admin-bar-logout a')->click();
+    }
+}

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -106,7 +106,7 @@ class Toolbar extends Element
                     // "Focus" (add hover class) on the toolbar link so the submenu appears
                     $id = $first_level_item->getAttribute('id');
                     $this->getDriver()->evaluateScript(
-                        'jQuery( "#' . $id . '" ).addClass("hover");'
+                        'jQuery("#' . $id . '").addClass("hover");'
                     );
                 } catch (UnsupportedDriverActionException $e) {
                     // This will fail for GoutteDriver but neither is it necessary
@@ -156,7 +156,7 @@ class Toolbar extends Element
         // manually add the hover class. See https://github.com/paulgibbs/behat-wordpress-extension/issues/65
         try {
             $this->getDriver()->evaluateScript(
-                'jQuery( "#wp-admin-bar-my-account" ).addClass("hover");'
+                'jQuery("#wp-admin-bar-my-account").addClass("hover");'
             );
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary


### PR DESCRIPTION
## Description

1. Adds a Toolbar object which makes defining steps involving interacting with the toolbar easier
2. Adds a `PageObjectContextTrait` which makes it easier for Contexts to create page/element objects.
3. Fixes the log-out step for JS-enabled drivers
4. Fixes the log-in step for Goutte driver
5. Adds tests


The `PageObjectContextTrait` means that classes that can't extend from `PageObjectContext` can still implement `PageObjectAwareContext` without having to actually duplicate the code.

## Related issue

Fixes #65  

(Also fixes bug introduced in #68).

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and context
The Toolbar encapsulates the WordPress toolbar and exposes an API for interacting with it. This makes steps interacting with it easier and simpler. 

It allows to fix #65 by using it's `logOut()` method. 

## How has this been tested?
Yes: https://travis-ci.org/stephenharris/behat-wordpress-extension/builds/209116022

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
