### PR TITLE
Fix Links / Buttons behind the wp-admin bar are inaccessible

### DIFF
--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -35,6 +35,27 @@ class WordpressContext extends RawWordpressContext implements PageObjectAware
     }
 
     /**
+     * When using the Selenium driver, position the admin bar to the top of the page, not fixed to the screen.
+     * Otherwise the admin toolbar can hide clickable elements.
+     *
+     * @BeforeStep
+     */
+    public function beforeStep(BeforeStepScope $scope)
+    {
+        $driver = $this->getSession()->getDriver();
+        if ($driver instanceof \Behat\Mink\Driver\Selenium2Driver && $driver->getWebDriverSession()) {
+            $this->getSession()->getDriver()->executeScript(
+                'if (document.getElementById("wpadminbar")){
+                    document.getElementById("wpadminbar").style.position="absolute";
+					if ( document.getElementsByTagName("body")[0].className.match(/wp-admin/) ) {
+						document.getElementById("wpadminbar").style.top="-32px";
+					}
+				};'
+            );
+        }
+    }
+
+    /**
      * Open the dashboard.
      *
      * Example: Given I am on the dashboard

--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -40,7 +40,7 @@ class WordpressContext extends RawWordpressContext implements PageObjectAware
      *
      * @BeforeStep
      */
-    public function beforeStep(BeforeStepScope $scope)
+    public function fixToolbar()
     {
         $driver = $this->getSession()->getDriver();
         if ($driver instanceof \Behat\Mink\Driver\Selenium2Driver && $driver->getWebDriverSession()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Rather than having the toolbar fixed to the top of the viewport, where it can potentially cover elements which we want to interact with, we position it at the top of the page.

## Related issue
#81

## Motivation and context
When using the Selenium driver, elements underneath the toolbar cannot be interacted with. Instead, Selenium errors with something similar to:

> Element is not clickable at point (577.0999755859375, 8.75). Other element would receive the click: <div id="wpadminbar" class=""></div>

## How has this been tested?
Yes, locally and on Travis.

## Screenshots (if appropriate):

See #81.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
