### PR TITLE
Drivers: update base Context methods to use new Driver interface.

### DIFF
--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -309,7 +309,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
         return array(
             'id'   => $content->ID,
             'slug' => $content->post_name,
-            //'url'  => $alt[0]->url,
+            'url'  => $content->url,
         );
     }
 

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -216,7 +216,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function clearCache()
     {
-        $this->getDriver()->clearCache();
+        $this->getDriver()->cache->clear();
     }
 
     /**
@@ -234,7 +234,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function activatePlugin($plugin)
     {
-        $this->getDriver()->activatePlugin($plugin);
+        $this->getDriver()->plugin->activate($plugin);
     }
 
     /**
@@ -244,7 +244,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function deactivatePlugin($plugin)
     {
-        $this->getDriver()->deactivatePlugin($plugin);
+        $this->getDriver()->plugin->deactivate($plugin);
     }
 
     /**
@@ -254,7 +254,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function switchTheme($theme)
     {
-        $this->getDriver()->switchTheme($theme);
+        $this->getDriver()->theme->change($theme);
     }
 
     /**
@@ -270,7 +270,15 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function createTerm($term, $taxonomy, $args = [])
     {
-        return $this->getDriver()->createTerm($term, $taxonomy, $args);
+        $args['taxonomy'] = $taxonomy;
+        $args['term']     = $term;
+
+        $term = $this->getDriver()->term->create($args);
+
+        return array(
+            'id'   => $term->term_id,
+            'slug' => $term->slug,
+        );
     }
 
     /**
@@ -281,7 +289,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function deleteTerm($term_id, $taxonomy)
     {
-        $this->getDriver()->deleteTerm($term_id, $taxonomy);
+        $this->getDriver()->term->delete($term_id, compact($taxonomy));
     }
 
     /**
@@ -291,11 +299,18 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      * @return array {
      *     @type int    $id   Content ID.
      *     @type string $slug Content slug.
+     *     @type string $url  Content permalink.
      * }
      */
     public function createContent($args)
     {
-        return $this->getDriver()->createContent($args);
+        $content = $this->getDriver()->content->create($args);
+
+        return array(
+            'id'   => $content->ID,
+            'slug' => $content->post_name,
+            //'url'  => $alt[0]->url,
+        );
     }
 
     /**
@@ -306,7 +321,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function deleteContent($id, $args = [])
     {
-        $this->getDriver()->deleteContent($id, $args);
+        $this->getDriver()->content->delete($id, $args);
     }
 
     /**
@@ -319,7 +334,11 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function createComment($args)
     {
-        return $this->getDriver()->createComment($args);
+        $comment = $this->getDriver()->comment->create($args);
+
+        return array(
+            'id' => $comment->comment_ID,
+        );
     }
 
     /**
@@ -330,7 +349,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function deleteComment($id, $args = [])
     {
-        $this->getDriver()->deleteComment($id, $args);
+        $this->getDriver()->comment->delete($id, $args);
     }
 
     /**
@@ -340,7 +359,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function exportDatabase()
     {
-        return $this->getDriver()->exportDatabase();
+        $this->getDriver()->database->export(0);
     }
 
     /**
@@ -350,7 +369,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function importDatabase($import_file)
     {
-        $this->getDriver()->importDatabase($import_file);
+        $this->getDriver()->database->import($import_file);
     }
 
     /**
@@ -366,7 +385,15 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function createUser($user_login, $user_email, $args = [])
     {
-        return $this->getDriver()->createUser($user_login, $user_email, $args);
+        $args['user_email'] = $user_email;
+        $args['user_login'] = $user_login;
+
+        $user = $this->getDriver()->user->create($args);
+
+        return array(
+            'id'   => $user->ID,
+            'slug' => $user->user_nicename,
+        );
     }
 
     /**
@@ -377,7 +404,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function deleteUser($id, $args = [])
     {
-        $this->getDriver()->deleteUser($id, $args);
+        $this->getDriver()->user->delete($id, $args);
     }
 
     /**
@@ -385,7 +412,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function startTransaction()
     {
-        $this->getDriver()->startTransaction();
+        $this->getDriver()->database->startTransaction();
     }
 
     /**
@@ -393,6 +420,6 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function endTransaction()
     {
-        $this->getDriver()->endTransaction();
+        $this->getDriver()->database->endTransaction();
     }
 }

--- a/src/Driver/Element/Wpapi/ContentElement.php
+++ b/src/Driver/Element/Wpapi/ContentElement.php
@@ -63,6 +63,8 @@ class ContentElement extends BaseElement
             throw new UnexpectedValueException(sprintf('Could not find content with ID %d', $id));
         }
 
+        $post->url = get_permalink($post);
+
         return $post;
     }
 

--- a/src/Driver/Element/Wpcli/ContentElement.php
+++ b/src/Driver/Element/Wpcli/ContentElement.php
@@ -45,11 +45,14 @@ class ContentElement extends BaseElement
      */
     public function get($id, $args = [])
     {
+        $url = '';
+
         // Support fetching via arbitary field.
         if (! is_numeric($id)) {
-            $wpcli_args = ['--field=ID', "--{$args['by']}=" . escapeshellarg($id), '--format=json'];
+            $wpcli_args = ['--fields=ID,url', "--{$args['by']}=" . escapeshellarg($id), '--format=json'];
             $result     = json_decode($this->drivers->getDriver()->wpcli('post', 'list', $wpcli_args)['stdout']);
-            $id         = (int) $result[0];
+            $id         = (int) $result[0]->ID;
+            $url        = $result[0]->url;
         }
 
         // Fetch by ID.
@@ -68,6 +71,14 @@ class ContentElement extends BaseElement
         if (! $post) {
             throw new UnexpectedValueException(sprintf('Could not find post with ID %d', $id));
         }
+
+        if (! $url) {
+            $wpcli_args = ['--field=url', '--ID=' . escapeshellarg($post->ID), '--format=json'];
+            $result     = json_decode($this->drivers->getDriver()->wpcli('post', 'list', $wpcli_args)['stdout']);
+            $url        = $result[0];
+        }
+
+        $post->url = $url;
 
         return $post;
     }


### PR DESCRIPTION
## Description

The driver re-organisation left the base Context using the backwards-compatible methods to test that they worked. This change updates those methods to use the new interfaces directly.

## Motivation and context
The backpat methods are planned to be removed in 1.0.0 and getting them out early helps us test more directly against those new interfaces as we build to feature completion.

## How has this been tested?
Tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.