### PR TITLE
Add a `site_url`-aware version of Mink's "I am on..." step.

### DIFF
--- a/features/readme.feature
+++ b/features/readme.feature
@@ -3,7 +3,6 @@ Feature: Accessing WordPress site
   In order to know this Apache is serving static HTML
   I'd like to check the WordPress readme.html is visible
 
-  @javascript
   Scenario: Visiting the homepage
-    Given I am on "/readme.html"
+    Given I am on "readme.html" from the site root
     Then I should see "WordPress is a very special project to me"

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -55,9 +55,10 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
             return $path;
         }
 
+        $ext = pathinfo($path, PATHINFO_EXTENSION);
         $url = $this->getMinkParameter('base_url');
 
-        if (strpos($path, 'wp-admin') !== false || strpos($path, '.php') !== false) {
+        if (strpos($path, 'wp-admin') !== false || in_array($ext, ['htm', 'html', 'md', 'php', 'txt'], true)) {
             $url = $this->getWordpressParameter('site_url');
         }
 

--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -117,4 +117,16 @@ class WordpressContext extends RawWordpressContext implements PageObjectAware
     {
         $this->getElement('Toolbar')->clickToolbarLink($link);
     }
+
+    /**
+     * A site_url-aware version of Mink's "I am on..." step.
+     *
+     * Example: Given I am on "readme.txt" from the site root.
+     *
+     * @Given I am on :url from the site root
+     */
+    public function iAmOnURLFromSiteRoot($url)
+    {
+        $this->visitPath($url);
+    }
 }


### PR DESCRIPTION
## Description
Fixes the `readme.txt` test, which was failing if WP was installed within a subdirectory.

## Motivation and context
Tests were failing if WP was installed within a subdirectory.

## How has this been tested?
Locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.