### PR TITLE
Feature: remove `readme` feature.

### DIFF
--- a/features/readme.feature
+++ b/features/readme.feature
@@ -1,9 +1,0 @@
-Feature: Accessing WordPress site
-  As a WordPress developer
-  In order to know this Apache is serving static HTML
-  I'd like to check the WordPress readme.html is visible
-
-  @javascript
-  Scenario: Visiting the homepage
-    Given I am on "/readme.html"
-    Then I should see "WordPress is a very special project to me"


### PR DESCRIPTION
Intended for debugging, no longer required. See #83

