### PR TITLE
Fix strict WP-Cli version requirement.

### DIFF
--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -69,7 +69,7 @@ class WpcliDriver extends BaseDriver
     {
         $version = '';
 
-        preg_match('#^WP-CLI (\d\.\d\.\d)$#', $this->wpcli('cli', 'version')['stdout'], $match);
+        preg_match('#^WP-CLI (.*)$#', $this->wpcli('cli', 'version')['stdout'], $match);
         if (! empty($match)) {
             $version = array_pop($match);
         }


### PR DESCRIPTION
We require WP Cli >= 0.24.0, but the current regex for extracting the version is too strict. It expects three single digits separated by full stops.

This breaks if you're running an alpha version and will break if/when WP-Cli
reaches double digits in version number. E.g  

```
wp --version
WP-CLI 1.2.0-alpha-9fda2a7

./vendor/bin/behat
╳ Your WP-CLI is too old; version 0.24.0 or newer is required. (RuntimeException)
```

## Description

This PR changes the regex to accept any string (after the WP CLI text) and passes it to `version_compare()`. That function is pretty good at handling anything you can throw at it. I wrote a quick script to check how it will handle various inputs, here are the results:

```
0.23.0-beta-1ekjfsaf	 ✗
0.24.1-alpha-13ga4	 ✓
0.24.0-alpha-13rab	 ✗
Im not a version	 ✗
0.24.0	 ✓
1	 ✓

✓ = version is considered >= 0.24.0
✗ = version is not considered >= 0.24.0
```

## Motivation and context

WordHat's WP-Cli driver requires a stable WP-Cli version and on consisting only of single digits.

## How has this been tested?

Tested manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
