### PR TITLE
Add a step for adding a widget to a sidebar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ script:
   # Execute all of the commands which should make the build pass or fail.
   - find ./src -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
   - vendor/bin/phpcs --standard=phpcs-ruleset.xml -p -s -v -n src --extensions=php
-  - export WP_CLI_STRICT_ARGS_MODE=1
   - vendor/bin/behat --config ./bin/travis/behat.yml
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ script:
   # Execute all of the commands which should make the build pass or fail.
   - find ./src -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
   - vendor/bin/phpcs --standard=phpcs-ruleset.xml -p -s -v -n src --extensions=php
+  - export WP_CLI_STRICT_ARGS_MODE=1
   - vendor/bin/behat --config ./bin/travis/behat.yml
 
 after_success:

--- a/bin/travis/behat.yml
+++ b/bin/travis/behat.yml
@@ -10,6 +10,7 @@ default:
         - PaulGibbs\WordpressBehatExtension\Context\SiteContext
         - PaulGibbs\WordpressBehatExtension\Context\UserContext
         - PaulGibbs\WordpressBehatExtension\Context\WordpressContext
+        - PaulGibbs\WordpressBehatExtension\Context\WidgetContext
 
   extensions:
     Behat\MinkExtension:

--- a/features/widget.feature
+++ b/features/widget.feature
@@ -1,0 +1,8 @@
+Feature: Widgets
+
+  Scenario: Viewing a widget
+    Given I have the "RSS" widget in "Sidebar"
+      | Title   | Url                              | Items   |
+      | My feed | https://wordpress.org/news/feed/ | 3       |
+    And I am on "/"
+    Then I should see "My feed"

--- a/src/Context/WidgetContext.php
+++ b/src/Context/WidgetContext.php
@@ -1,0 +1,32 @@
+<?php
+namespace PaulGibbs\WordpressBehatExtension\Context;
+
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Provides step definitions relating to widgets
+ */
+class WidgetContext extends RawWordpressContext
+{
+
+    /**
+     * Adds a widget (identified by its ID base) to the sidebar (identified by it's human-readable name, e.g. 'Widget
+     * Area', 'Right Sidebar', or 'Footer') with the given arguments.
+     *
+     * Example: Given I have the "Meta" widget in "Widget Area
+     * Example: Given I have the "RSS" widget in "Widget Area"
+     *            | Title   | Url                              | Items   |
+     *            | My feed | https://wordpress.org/news/feed/ | 3       |
+     *
+     * @Given I have the :widget_name widget in :sidebar_name
+     */
+    public function iHaveTheMetaWidgetIn($widget_name, $sidebar_name, TableNode $widget_settings)
+    {
+        $sidebar = $this->getDriver()->widget->getSidebar($sidebar_name);
+
+        $keys = array_map('strtolower', $widget_settings->getRow(0));
+        $values = $widget_settings->getRow(1); //we only support one widget for now
+        $args = array_combine($keys, $values);
+        $this->getDriver()->widget->addToSidebar($widget_name, $sidebar, $args);
+    }
+}

--- a/src/Driver/Element/Wpapi/WidgetElement.php
+++ b/src/Driver/Element/Wpapi/WidgetElement.php
@@ -16,7 +16,7 @@ class WidgetElement extends BaseElement
      * @param string $widget_name The ID base of the widget (e.g. 'meta', 'calendar'). Case insensitive.
      * @param string $sidebar_id The ID of the sidebar to the add the widget to
      * @param array $args Associative array of widget settings for this widget
-     * @throws \Exception If the widget is not registered.
+     * @throws UnexpectedValueException If the widget is not registered.
      */
     public function addToSidebar($widget_name, $sidebar_id, $args)
     {
@@ -57,7 +57,7 @@ class WidgetElement extends BaseElement
      *
      * @param string $sidebar_name The name of the sidebar (e.g. 'Footer', 'Widget Area', 'Right Sidebar')
      * @return string The sidebar ID
-     * @throws \Exception If the sidebar is not registered
+     * @throws UnexpectedValueException If the sidebar is not registered
      */
     public function getSidebar($sidebar_name)
     {

--- a/src/Driver/Element/Wpapi/WidgetElement.php
+++ b/src/Driver/Element/Wpapi/WidgetElement.php
@@ -1,0 +1,81 @@
+<?php
+namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi;
+
+use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use UnexpectedValueException;
+
+/**
+ * WP-API driver element for managing user accounts.
+ */
+class WidgetElement extends BaseElement
+{
+
+    /**
+     * Adds a widget to the sidebar with the specified arguments
+     *
+     * @param string $widget_name The ID base of the widget (e.g. 'meta', 'calendar'). Case insensitive.
+     * @param string $sidebar_id The ID of the sidebar to the add the widget to
+     * @param array $args Associative array of widget settings for this widget
+     * @throws \Exception If the widget is not registered.
+     */
+    public function addToSidebar($widget_name, $sidebar_id, $args)
+    {
+        global $wp_widget_factory;
+
+        $widget_name = strtolower($widget_name);
+        $widget = wp_filter_object_list($wp_widget_factory->widgets, array( 'id_base' => $widget_name ));
+
+        if (! $widget) {
+            throw new UnexpectedValueException(sprintf('Widget "%s" does not exist', $widget_name));
+        }
+        $widget = array_pop($widget);
+
+        $widget_options = get_option('widget_' . $widget_name, array());
+        $option_keys = array_keys($widget_options);
+        unset($option_keys['_multiwidget']);
+        if (! isset($widget_options['_multiwidget'])) {
+            $widget_options['_multiwidget'] = 1;
+        }
+
+        // Get the widgets 'counter'
+        $last_key = array_pop($option_keys);
+        $counter = $last_key + 1;
+
+        // Create widget instance
+        $widget_options[ $counter ] = $widget->update($args, array());
+        update_option('widget_' . $widget_name, $widget_options);
+        $widget_id = $widget_name . '-' . $counter;
+
+        // Add widget to sidebar
+        $active_widgets = get_option('sidebars_widgets', array());
+        array_unshift($active_widgets[ $sidebar_id ], $widget_id);
+        update_option('sidebars_widgets', $active_widgets);
+    }
+
+    /**
+     * Gets a sidebar ID from its human-readable name
+     *
+     * @param string $sidebar_name The name of the sidebar (e.g. 'Footer', 'Widget Area', 'Right Sidebar')
+     * @return string The sidebar ID
+     * @throws \Exception If the sidebar is not registered
+     */
+    public function getSidebar($sidebar_name)
+    {
+        global $wp_registered_sidebars;
+
+        $sidebar_id = null;
+        $sidebars = [];
+        foreach ($wp_registered_sidebars as $registered_sidebar_id => $registered_sidebar) {
+            $sidebars[] = $registered_sidebar['name'];
+            if ($sidebar_name == $registered_sidebar['name']) {
+                $sidebar_id = $registered_sidebar_id;
+                break;
+            }
+        }
+
+        if (is_null($sidebar_id)) {
+            throw new UnexpectedValueException(sprintf('Sidebar "%s" does not exist', $sidebar_name));
+        }
+        return $sidebar_id;
+    }
+}

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -3,6 +3,7 @@ namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
 use UnexpectedValueException;
+use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
 
 /**
  * WP-API driver element for managing user accounts.
@@ -22,15 +23,10 @@ class WidgetElement extends BaseElement
     {
         $widget_name = strtolower($widget_name);
 
-        foreach ($args as $key => $value) {
-            $args['--' . $key] = $value;
-            unset($args[$key]);
-        }
-
         $wpcli_args = [
                 $widget_name,
                 $sidebar_id
-            ] + $args;
+            ] + buildCLIArgs( array_keys( $args ), $args );
 
         $this->drivers->getDriver()->wpcli('widget', 'add', $wpcli_args);
     }
@@ -45,7 +41,7 @@ class WidgetElement extends BaseElement
     public function getSidebar($sidebar_name)
     {
         $registered_sidebars = json_decode($this->drivers->getDriver()->wpcli('sidebar', 'list', [
-            '--format' => 'json',
+            '--format=json',
         ])['stdout']);
 
         $sidebar_id = null;

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -26,7 +26,7 @@ class WidgetElement extends BaseElement
         $wpcli_args = [
                 $widget_name,
                 $sidebar_id
-            ] + buildCLIArgs( array_keys( $args ), $args );
+            ] + buildCLIArgs(array_keys($args), $args);
 
         $this->drivers->getDriver()->wpcli('widget', 'add', $wpcli_args);
     }

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -17,7 +17,7 @@ class WidgetElement extends BaseElement
      * @param string $widget_name The ID base of the widget (e.g. 'meta', 'calendar'). Case insensitive.
      * @param string $sidebar_id The ID of the sidebar to the add the widget to
      * @param array $args Associative array of widget settings for this widget
-     * @throws \Exception If the widget is not registered.
+     * @throws UnexpectedValueException If the widget or sidebar does not exist.
      */
     public function addToSidebar($widget_name, $sidebar_id, $args)
     {
@@ -36,7 +36,7 @@ class WidgetElement extends BaseElement
      *
      * @param string $sidebar_name The name of the sidebar (e.g. 'Footer', 'Widget Area', 'Right Sidebar')
      * @return string The sidebar ID
-     * @throws \Exception If the sidebar is not registered
+     * @throws UnexpectedValueException If the sidebar is not registered
      */
     public function getSidebar($sidebar_name)
     {

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -61,5 +61,4 @@ class WidgetElement extends BaseElement
         }
         return $sidebar_id;
     }
-
 }

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -23,10 +23,10 @@ class WidgetElement extends BaseElement
     {
         $widget_name = strtolower($widget_name);
 
-        $wpcli_args = [
+        $wpcli_args = array_merge([
                 $widget_name,
                 $sidebar_id
-            ] + buildCLIArgs(array_keys($args), $args);
+            ], buildCLIArgs(array_keys($args), $args));
 
         $this->drivers->getDriver()->wpcli('widget', 'add', $wpcli_args);
     }

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -1,0 +1,65 @@
+<?php
+namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+
+use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use UnexpectedValueException;
+
+/**
+ * WP-API driver element for managing user accounts.
+ */
+class WidgetElement extends BaseElement
+{
+
+    /**
+     * Adds a widget to the sidebar with the specified arguments
+     *
+     * @param string $widget_name The ID base of the widget (e.g. 'meta', 'calendar'). Case insensitive.
+     * @param string $sidebar_id The ID of the sidebar to the add the widget to
+     * @param array $args Associative array of widget settings for this widget
+     * @throws \Exception If the widget is not registered.
+     */
+    public function addToSidebar($widget_name, $sidebar_id, $args)
+    {
+        $widget_name = strtolower($widget_name);
+
+        foreach ($args as $key => $value) {
+            $args['--' . $key] = $value;
+            unset($args[$key]);
+        }
+
+        $wpcli_args = [
+                $widget_name,
+                $sidebar_id
+            ] + $args;
+
+        $this->drivers->getDriver()->wpcli('widget', 'add', $wpcli_args);
+    }
+
+    /**
+     * Gets a sidebar ID from its human-readable name
+     *
+     * @param string $sidebar_name The name of the sidebar (e.g. 'Footer', 'Widget Area', 'Right Sidebar')
+     * @return string The sidebar ID
+     * @throws \Exception If the sidebar is not registered
+     */
+    public function getSidebar($sidebar_name)
+    {
+        $registered_sidebars = json_decode($this->drivers->getDriver()->wpcli('sidebar', 'list', [
+            '--format' => 'json',
+        ])['stdout']);
+
+        $sidebar_id = null;
+        foreach ($registered_sidebars as $sidebar) {
+            if ($sidebar_name == $sidebar->name) {
+                $sidebar_id = $sidebar->id;
+                break;
+            }
+        }
+
+        if (is_null($sidebar_id)) {
+            throw new UnexpectedValueException(sprintf('Sidebar "%s" does not exist', $sidebar_name));
+        }
+        return $sidebar_id;
+    }
+
+}

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -1,4 +1,4 @@
-d<?php
+<?php
 namespace PaulGibbs\WordpressBehatExtension\Driver;
 
 use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -83,6 +83,8 @@ class WpcliDriver extends BaseDriver
             throw new RuntimeException('WP-CLI driver cannot find WordPress. Check "path" and/or "alias" settings.');
         }
 
+        putenv('WP_CLI_STRICT_ARGS_MODE=1');
+
         $this->is_bootstrapped = true;
     }
 

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -1,4 +1,4 @@
-<?php
+d<?php
 namespace PaulGibbs\WordpressBehatExtension\Driver;
 
 use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;

--- a/src/ServiceContainer/config/drivers/wpapi.yml
+++ b/src/ServiceContainer/config/drivers/wpapi.yml
@@ -8,6 +8,7 @@ parameters:
   wordpress.element.wpapi.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\TermElement
   wordpress.element.wpapi.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\ThemeElement
   wordpress.element.wpapi.user.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\UserElement
+  wordpress.element.wpcli.widgets.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\WidgetElement
 
 services:
   wordpress.driver.wpapi:
@@ -72,3 +73,10 @@ services:
       - "@wordpress.wordpress"
     tags:
       - { name: wordpress.element, alias: user, driver: wpapi }
+
+  wordpress.element.wpapi.widgets:
+    class: %wordpress.element.wpapi.widgets.class%
+    arguments:
+      - "@wordpress.wordpress"
+    tags:
+      - { name: wordpress.element, alias: widgets, driver: wpapi }

--- a/src/ServiceContainer/config/drivers/wpapi.yml
+++ b/src/ServiceContainer/config/drivers/wpapi.yml
@@ -8,7 +8,7 @@ parameters:
   wordpress.element.wpapi.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\TermElement
   wordpress.element.wpapi.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\ThemeElement
   wordpress.element.wpapi.user.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\UserElement
-  wordpress.element.wpcli.widgets.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\WidgetElement
+  wordpress.element.wpapi.widget.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpapi\WidgetElement
 
 services:
   wordpress.driver.wpapi:
@@ -74,9 +74,9 @@ services:
     tags:
       - { name: wordpress.element, alias: user, driver: wpapi }
 
-  wordpress.element.wpapi.widgets:
-    class: %wordpress.element.wpapi.widgets.class%
+  wordpress.element.wpapi.widget:
+    class: %wordpress.element.wpapi.widget.class%
     arguments:
       - "@wordpress.wordpress"
     tags:
-      - { name: wordpress.element, alias: widgets, driver: wpapi }
+      - { name: wordpress.element, alias: widget, driver: wpapi }

--- a/src/ServiceContainer/config/drivers/wpcli.yml
+++ b/src/ServiceContainer/config/drivers/wpcli.yml
@@ -8,6 +8,7 @@ parameters:
   wordpress.element.wpcli.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\TermElement
   wordpress.element.wpcli.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\ThemeElement
   wordpress.element.wpcli.user.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\UserElement
+  wordpress.element.wpcli.widgets.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\WidgetElement
 
 services:
   wordpress.driver.wpcli:
@@ -75,3 +76,10 @@ services:
       - "@wordpress.wordpress"
     tags:
       - { name: wordpress.element, alias: user, driver: wpcli }
+
+  wordpress.element.wpcli.widgets:
+    class: %wordpress.element.wpcli.widgets.class%
+    arguments:
+      - "@wordpress.wordpress"
+    tags:
+      - { name: wordpress.element, alias: widgets, driver: wpcli }

--- a/src/ServiceContainer/config/drivers/wpcli.yml
+++ b/src/ServiceContainer/config/drivers/wpcli.yml
@@ -8,7 +8,7 @@ parameters:
   wordpress.element.wpcli.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\TermElement
   wordpress.element.wpcli.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\ThemeElement
   wordpress.element.wpcli.user.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\UserElement
-  wordpress.element.wpcli.widgets.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\WidgetElement
+  wordpress.element.wpcli.widget.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\WidgetElement
 
 services:
   wordpress.driver.wpcli:
@@ -77,9 +77,9 @@ services:
     tags:
       - { name: wordpress.element, alias: user, driver: wpcli }
 
-  wordpress.element.wpcli.widgets:
-    class: %wordpress.element.wpcli.widgets.class%
+  wordpress.element.wpcli.widget:
+    class: %wordpress.element.wpcli.widget.class%
     arguments:
       - "@wordpress.wordpress"
     tags:
-      - { name: wordpress.element, alias: widgets, driver: wpcli }
+      - { name: wordpress.element, alias: widget, driver: wpcli }


### PR DESCRIPTION
## Description

Defines a step for adding a widget to a sidebar, e.g.

   > Given I have the "RSS" widget in "Widget Area"
   > | Title   | Url                              | Items   |
   > | My feed | https://wordpress.org/news/feed/ | 3       

Adds a new element for the WP-Cli and WP API drivers to support this step.

It also adds `export WP_CLI_STRICT_ARGS_MODE=1` to the set up. In WP-Cli 'strict' mode allows you to use the `--url` argument multiple times. By default `--url` is a global parameter that refers to the site URL, but it may also be an argument to the command being run (see`widget.feature` for an example). 

Strict mode allows you to distinguish between the two: `--url` before the command refers to the [global parameter](https://make.wordpress.org/cli/handbook/config/#global-parameters) and `--url` after the command is interpreted to be an argument of that command. (See: https://make.wordpress.org/cli/handbook/config/#environment-variables )

## Motivation and context
To facilitate the testing of widgets and/or widget visibility.

## How has this been tested?
Yes, manually and on Travis. `widget.feature` has been added to support this new feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
