### PR TITLE
Try improvements to the log-in step.

### DIFF
--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -166,6 +166,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary
         }
+        $node->setValue('');
         $node->setValue($username);
 
         $node = $page->findField('user_pass');
@@ -174,6 +175,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary
         }
+        $node->setValue('');
         $node->setValue($password);
 
         $page->findButton('wp-submit')->click();


### PR DESCRIPTION
For unknown reasons, Behat/Mink seems to have problems logging into WordPress on an occassional and intermittent basis. A common failure is that Mink does not enter the username or password into the correct elements on the log-in form, or leaves one blank.

We've iterated fixes several times -- some environment specific, e.g. Travis-CI -- and this commit spins the wheel once more.

My local testing, and on Travis-CI, suggests this change improves the reliability of entering data into the log-in form. The idea is clearing the field values prior to data entry works around some sort of quirk in WebDriver/Selenium.

See #47.

