### PR TITLE
Features: remove `insulated` keyword from all tests.

### DIFF
--- a/features/toolbar.feature
+++ b/features/toolbar.feature
@@ -4,36 +4,36 @@ Feature: Toolbar
     Given I am logged in as an admin
     And I am on "/"
 
-  @javascript @insulated
+  @javascript
   Scenario: I can go to the support forums
     When I follow the toolbar link "WordPress > Support Forums"
     Then I should be on "https://wordpress.org/support/"
 
-  @javascript @insulated
+  @javascript
   Scenario: I can add a new page
     When I follow the toolbar link "New > Page"
     Then I should be on the "Add New Page" page
 
-  @javascript @insulated
+  @javascript
   Scenario: I can select a site
     When I follow the toolbar link "wordpress.dev > Widgets"
     Then I should be on the "Widgets" page
 
-  @javascript @insulated
+  @javascript
   Scenario: I can go to comments
     When I follow the toolbar link "Comments"
     Then I should be on the "Comments" page
 
-  @javascript @insulated
+  @javascript
   Scenario: I can go to edit my profile
     When I follow the toolbar link "Howdy, admin > Edit My Profile"
     Then I should be on the "Profile" page
 
-  @javascript @insulated
+  @javascript
   Scenario: I can search using the toolbar
     When I search for "Hello World" in the toolbar
     Then I should see "Search results"
 
-  @javascript @insulated
+  @javascript
   Scenario: I can a greeting in the toolbar
     Then I should see "Howdy, admin" in the toolbar


### PR DESCRIPTION
## Description
This should not be required; the `WordPressContext`'s `resetBrowser()` instructs Mink to soft-reset the browser (clear cookies, etc).

My testing suggests this is no longer required as long as the `WordPressContext` is specified in `behat.yml`, which is our recommendation.

## How has this been tested?
Local and on Travis-CI.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
