### PR TITLE
Tweak which tests can use the `javascript` tag or not.

### DIFF
--- a/features/toolbar.feature
+++ b/features/toolbar.feature
@@ -1,39 +1,33 @@
+@javascript
 Feature: Toolbar
 
   Background:
     Given I am logged in as an admin
     And I am on the homepage
 
-  @javascript
   Scenario: I can go to the support forums
     When I follow the toolbar link "WordPress > Support Forums"
     Then I should be on "https://wordpress.org/support/"
 
-  @javascript
   Scenario: I can add a new page
     When I follow the toolbar link "New > Page"
     Then I should be on the "Add New Page" page
 
-  @javascript
   Scenario: I can select a site
     When I follow the toolbar link "wordpress.dev > Widgets"
     Then I should be on the "Widgets" page
 
-  @javascript
   Scenario: I can go to comments
     When I follow the toolbar link "Comments"
     Then I should be on the "Comments" page
 
-  @javascript
   Scenario: I can go to edit my profile
     When I follow the toolbar link "Howdy, admin > Edit My Profile"
     Then I should be on the "Profile" page
 
-  @javascript
   Scenario: I can search using the toolbar
     When I search for "Hello World" in the toolbar
     Then I should see "Search results"
 
-  @javascript
   Scenario: I can a greeting in the toolbar
     Then I should see "Howdy, admin" in the toolbar

--- a/features/user.feature
+++ b/features/user.feature
@@ -2,9 +2,8 @@ Feature: Managing users
 
   Background:
     Given I am logged in as an admin
-		And I am on the Dashboard
+    And I am on the Dashboard
 
-  @javascript
   Scenario: I can add a new user
     Given I go to menu item "Users"
     When I click on the "Add New" link in the header
@@ -14,6 +13,8 @@ Feature: Managing users
     And I fill in "email" with "neweditor@example.org"
     And I fill in "first_name" with "Ed"
     And I fill in "last_name" with "New"
+    And I fill in "pass1" with "password"
+    And I fill in "pass2" with "password"
     And I select "editor" from "role"
     And I press "Add New User"
     Then I should see a status message that says "New user created"


### PR DESCRIPTION
## Description
Our previous approach to "which tests have to run with JS" was not formally defined and was basically "use it where it helps make the tests more realistic". I agree to a point, but we need to be more specific.

For tests that touch the Toolbar, given the hacks we have to do to support it already, let's have those always use javascript. Ditto for anything known trouble areas, like User authentication.

We were pretty much doing this already; this PR just changes the syntax a little bit, and removes javascript from one test.

## Motivation and context
Non-JS tests are faster.

## How has this been tested?
Locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.