### PR TITLE
Features, Log-in: do not use multiple "givens" in a single scenario.

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -5,14 +5,12 @@ Feature: Logging in, Logging out
     Given I am logged in as an admin
     And I am on the Dashboard
     Then I should see "Howdy"
-
-    Given I am an anonymous user
+    When I log out
     Then I should not see "Howdy"
 
   Scenario: I can log-in and out (no-js)
     Given I am logged in as an admin
     And I am on the Dashboard
     Then I should see "Howdy"
-
-    Given I am an anonymous user
+    When I log out
     Then I should not see "Howdy"

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -78,8 +78,10 @@ class UserContext extends RawWordpressContext
      * Log user out.
      *
      * Example: Given I am an anonymous user
+     * Example: When I log out
      *
      * @Given /^(?:I am|they are) an anonymous user/
+     * @When I log out
      */
     public function iAmAnonymousUser()
     {


### PR DESCRIPTION
## Description
Do not use multiple "givens" in a single scenario in the log-in feature.
These scenarios are a little unusual because we are testing the log-out flow, but I don't think it looks right to have multiple givens to set state. Further more, while "I am an anonymous user" does log you out, it was clearer to replace it with something that explicitly said "I log out".

## Motivation and context
Clarity.

## How has this been tested?
Locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.