### PR TITLE
@BeforeStep throws exception on initial step in @javascript scenario

### DIFF
--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -47,14 +47,17 @@ class WordpressContext extends RawWordpressContext implements PageObjectAware
             return;
         }
 
-        $this->getSession()->getDriver()->executeScript(
-            'if (document.getElementById("wpadminbar")) {
-                document.getElementById("wpadminbar").style.position="absolute";
-                if (document.getElementsByTagName("body")[0].className.match(/wp-admin/)) {
-                    document.getElementById("wpadminbar").style.top="-32px";
-                }
-            };'
-        );
+        try {
+            $this->getSession()->getDriver()->executeScript(
+                'if (document.getElementById("wpadminbar")) {
+                    document.getElementById("wpadminbar").style.position="absolute";
+                    if (document.getElementsByTagName("body")[0].className.match(/wp-admin/)) {
+                        document.getElementById("wpadminbar").style.top="-32px";
+                    }
+                };'
+            );
+        } catch (\Exception $e) {
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

In a javascript scenario (when using Selenium) we run a @BeforeStep hook to address the issue of the admin toolbar hiding elements (and thus potentially making them unclickable). 

If a browser window is not open, then `Selenium2Driver::executeScript()` will throw an 'unknown'. This typically happens when there are no background steps which open a browser window (the `@BeforeStep` does not run for them.

Obviously, in such situations this workaround is not required (it's only an issue when we are interacting with the page via the browser.). So the solution is to catch the exception and let it fail silently.

## Motivation and context

My test are currently failing for no good reason :)

## How has this been tested?
Yes, via tests written for clients

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
