### PR TITLE
CI: disable Travis-CI `pip` caching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 
 cache:
   apt: true
-  pip: true
   directories:
     - vendor
     - $HOME/.composer/cache


### PR DESCRIPTION
## Description
Disable Travis-CI `pip` caching.

## Motivation and context
We use Mkdocs to build the website with its Material theme.
Disabling Python caching will ensure we always build the website with the latest version of the template.

Previously I was occasionally clearing Travis-CI's cache manually to prevent this.

## How has this been tested?
Not at all.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.