### PR TITLE
Friendlier error message when WordPress core is not installed

### DIFF
--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -85,7 +85,7 @@ class WpcliDriver extends BaseDriver
 
         $status = $this->wpcli('core', 'is-installed')['exit_code'];
         if ($status !== 0) {
-            throw new RuntimeException('WP-CLI driver cannot find WordPress. Check "path" and/or "alias" settings.');
+            throw new RuntimeException('WordPress does not seem to be installed. Please install WordPress. If WordPress is installed, the WP-CLI driver cannot find WordPress. Please check the "path" and/or "alias" settings in behat.yml.');
         }
 
         putenv('WP_CLI_STRICT_ARGS_MODE=1');


### PR DESCRIPTION
## Description
See #112 for details

## Motivation and context
Allow users to know the issue is WordPress core not being installed rather than wpcli not finding the WordPress core files.

## How has this been tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
