### PR TITLE
Don't use realpath if it doesn't resolve to a valid path

### DIFF
--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -52,6 +52,10 @@ class WpcliDriver extends BaseDriver
     {
         $this->alias = ltrim($alias, '@');
         $this->path  = realpath($path);
+        // don't use realpath if it doesn't resolve to a valid path
+        if( false === $this->path ) {
+            $this->path = $path;
+        }
         $this->url   = rtrim(filter_var($url, FILTER_SANITIZE_URL), '/');
 
         // Support Windows.

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -53,7 +53,7 @@ class WpcliDriver extends BaseDriver
         $this->alias = ltrim($alias, '@');
         $this->path  = realpath($path);
         // don't use realpath if it doesn't resolve to a valid path
-        if( false === $this->path ) {
+        if (false === $this->path) {
             $this->path = $path;
         }
         $this->url   = rtrim(filter_var($url, FILTER_SANITIZE_URL), '/');


### PR DESCRIPTION
wpcli allows relative paths but the wpcli driver requires absolute paths by making use of `realpath`. 

## Description
Don't use `realpath` if it doesn't resolve to a valid path.

## Related issue
See #114 

## Motivation and context
There are scenarios when the full path is not know, such as testing on container based infrastructure where paths may change as containers shift.

## How has this been tested?
Tested the PR code using WordHat locally against a remote staging site with a relative path for wpcli.

## Screenshots (if appropriate):
<img width="1280" alt="screen shot 2017-07-12 at 2 20 35 pm" src="https://user-images.githubusercontent.com/2133004/28140478-5a2b7f98-670d-11e7-84d0-427e2295e5a4.png">


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
