### PR TITLE
Don't fail WordHat tests when wpcli returns stderr output

### DIFF
--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -124,23 +124,20 @@ class WpcliDriver extends BaseDriver
             "{$this->binary} {$config} --no-color {$command} {$subcommand} {$arguments}",
             array(
                 1 => ['pipe', 'w'],
-                2 => ['pipe', 'w'],
             ),
             $pipes
         );
 
         $stdout = trim(stream_get_contents($pipes[1]));
-        $stderr = trim(stream_get_contents($pipes[2]));
         fclose($pipes[1]);
-        fclose($pipes[2]);
         $exit_code = proc_close($proc);
 
-        if ($exit_code || $stderr || strpos($stdout, 'Warning: ') === 0 || strpos($stdout, 'Error: ') === 0) {
+        if ($exit_code || strpos($stdout, 'Warning: ') === 0 || strpos($stdout, 'Error: ') === 0) {
             throw new UnexpectedValueException(
                 sprintf(
                     "WP-CLI driver failure in method %1\$s(): \n\t%2\$s\n(%3\$s)",
                     debug_backtrace()[1]['function'],
-                    $stderr ?: $stdout,
+                    $stdout,
                     $exit_code
                 )
             );


### PR DESCRIPTION
## Description
wpcli sometimes sends warnings, such as `"Plugin '{$plugin->name}' is already active."`, to `stderr`. WordHat should not fail in these instances. Instead we should rely on wpcli returning an exit code greater than zero when there are legitimate errors.

## Related issue
See #111 

## Motivation and context
Custom tests making use of WordHat are failing when using the wpcli driver and wpcli returns warning messages to `stderr`. Ideally the warnings would be shown yet the WordHat tests would still pass.

## How has this been tested?
Tested against tests activating plugins that are already active.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
