### PR TITLE
Contexts, Dashboard: change "I am on the dashboard" step to check URL.

### DIFF
--- a/src/PageObject/DashboardPage.php
+++ b/src/PageObject/DashboardPage.php
@@ -1,6 +1,8 @@
 <?php
 namespace PaulGibbs\WordpressBehatExtension\PageObject;
 
+use Behat\Mink\Exception\ExpectationException;
+
 /**
  * Page object representing the wp-admin "Dashboard" screen.
  */
@@ -12,12 +14,24 @@ class DashboardPage extends AdminPage
     protected $path = '/wp-admin/index.php';
 
     /**
-     * Asserts the page header tag reads 'Dashboard'
+     * Asserts the current screen is the Dashboard.
      *
-     * @throws \Exception
+     * @throws ExpectationException
      */
     protected function verifyPage()
     {
-        $this->assertHasHeader('Dashboard');
+        $url = $this->getSession()->getCurrentUrl();
+
+        if (strrpos($url, $this->path) !== false) {
+            return;
+        }
+
+        throw new ExpectationException(
+            sprintf(
+                'Expected page is the wp-admin dashboard, instead on "%1$s".',
+                $url
+            ),
+            $this->getDriver()
+        );
     }
 }


### PR DESCRIPTION
## Description
Per title. The value we were comparing against was in English, which is limiting if we support multilingual step definitions in the future.
I'd rather have the code written flexibly and solve the step definition translation puzzle later.

## Related issue
#132 

## How has this been tested?
Locally against existing test suite, which covers the changed method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.