### PR TITLE
Fix 128

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -17,7 +17,7 @@ Feature: Managing users
     Then the toolbar should show I am authenticated as test
   
   @javascript @db
-  Scenario: I can specify a user which does not exist and the test should not fail
+  Scenario: I can specify a user which already exists and the test should not fail
     Given there are users:
        | user_login | user_pass | user_email        | role          |
        | test       | test      | test@example.com  | author        |

--- a/features/user.feature
+++ b/features/user.feature
@@ -15,3 +15,15 @@ Feature: Managing users
     And I am logged in as a test
     When I go to the dashboard
     Then the toolbar should show I am authenticated as test
+  
+  @javascript @db
+  Scenario: I can specify a user which does not exist and the test should not fail
+    Given there are users:
+       | user_login | user_pass | user_email        | role          |
+       | test       | test      | test@example.com  | author        |
+    And there are users:
+       | user_login | user_pass | user_email        | role          |
+       | test       | test      | test@example.com  | author        |
+    And I am logged in as a test
+    When I go to the dashboard
+    Then the toolbar should show I am authenticated as test

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -18,8 +18,7 @@ trait UserAwareContextTrait
      *
      * @param string $username
      * @param string $password
-     * @param string $redirect_to
-     *            Optional. After succesful log in, redirect browser to this path. Default = "/".
+     * @param string $redirect_to Optional. After succesful log in, redirect browser to this path. Default = "/".
      *
      * @throws ExpectationException
      */

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -202,8 +202,7 @@ trait UserAwareContextTrait
     /**
      * Checks to see if the passed in parameter applies to a user or not.
      *
-     * @param string $user_parameter
-     *            the parameter to be checked.
+     * @param string $user_parameter the parameter to be checked.
      *
      * @return boolean $retval True if the parameter does apply to a user.
      */

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -4,6 +4,7 @@ namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use UnexpectedValueException;
 
 /**
  * Provides driver agnostic logic (helper methods) relating to users.
@@ -87,11 +88,16 @@ trait UserAwareContextTrait
 
 
     /**
-     * Create a user.
+     * Create a user. If the user already exists, the existing user will be
+     * compared with the user which was asked to be created. If all matches
+     * no fault with be thrown. If it does not match then UnexpectedValueException
+     * will be thrown.
      *
      * @param string $userLogin  User login name.
      * @param string $userEmail  User email address.
      * @param array  $args        Optional. Extra parameters to pass to WordPress.
+     *
+     * @throws \UnexpectedValueException
      *
      * @return array {
      *         @type int $id User ID.
@@ -103,12 +109,101 @@ trait UserAwareContextTrait
         $args['user_email'] = $userEmail;
         $args['user_login'] = $userLogin;
 
-        $user = $this->getDriver()->user->create($args);
+        try {
+            $user = $this->getDriver()->user->create($args);
+        } catch (UnexpectedValueException $exception) {
+            $user = $this->getExistingMatchingUser($args);
+        }
 
-        return array(
+        $return_array = array(
             'id'   => $user->ID,
             'slug' => $user->user_nicename
         );
+
+        return $return_array;
+    }
+
+    /**
+     * Returns a user if all the passed parameters match
+     * throws an UnexpectedValueException if not
+     *
+     * if there is return a user ID
+     *
+     * @throws \UnexpectedValueException
+     * @return \WP_User $user
+     */
+    private function getExistingMatchingUser($args)
+    {
+
+        $user_id = $this->getUserIdFromLogin($args['user_login']);
+        $user = $this->getDriver()->user->get($user_id);
+
+        /* users can have more than one role, so treat this as a
+         * special case. If role is specified then check its in the roles
+         * array in the existing user. If an entire roles array is specified
+         * then it will need to match exactly. The latter case is handled like any other
+         * parameter.
+         */
+
+        // $user->role can either be a string with 1 role in it or an array of roles.
+        if (array_key_exists('role', $args)) {
+            if (is_string($user->roles)) {
+                if ($user->roles != $args['role']) { // if its a string check it matches the role
+                    throw new \UnexpectedValueException('User with login : ' . $user->user_login .
+                        'exists, but role : ' . $args['role'] . ' does not match the applied role : ' . $user->roles);
+                }
+            } elseif (!in_array($args['role'], $user->roles)) { // if its an array check the role is in that array
+                throw new \UnexpectedValueException('User with login : ' . $user->user_login .
+                    'exists, but role : ' . $args['role'] . ' is not in the list of applied roles : ' . $user->roles);
+            }
+        }
+
+        /* Loop through each of the passed arguements.
+         * if they are arguments which apply to users
+         * then check that that which exist matches that which was specified.
+         */
+        foreach ($args as $parameter => $value) {
+            if ($parameter == 'password') {
+                try {
+                    if (!$this->getDriver()->user->validateCredentials($args['user_login'], $value)) {
+                        throw new \UnexpectedValueException('User with login : ' . $user->user_login . ' exists but password is incorrect');
+                    }
+                } catch (UnsupportedDriverActionException $exception) {
+                    // WPCLI can't do this yet.
+                }
+            }
+            if ($this->isValidUserParameter($parameter) && $user->$parameter != $args[$parameter]) {
+                throw new \UnexpectedValueException('User with login : ' . $user->user_login .
+                    'exists, but ' . $parameter . ' is ' . $user->$parameter .
+                    ' not ' . $args[$parameter] . 'which was specified');
+            }
+        }
+
+        return $user;
+    }
+
+    /**
+     * Checks to see if the passed in parameter applies to a user or not.
+     *
+     * @param string $user_parameter the parameter to be checked.
+     *
+     * @return boolean $retval True if the parameter does apply to a user.
+     */
+    private function isValidUserParameter(string $user_parameter)
+    {
+        $validUserParameters = array('id',
+            'user_login',
+            'display_name',
+            'user_email',
+            'user_registered',
+            'roles',
+//            'user_pass', - exclude the password for the moment - need special logic for it
+            'user_nicename',
+            'user_url',
+            'user_activation_key',
+            'user_status',
+            'url');
+        return in_array(strtolower($user_parameter), $validUserParameters);
     }
 
     /**

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -93,18 +93,15 @@ trait UserAwareContextTrait
      * no fault with be thrown. If it does not match then UnexpectedValueException
      * will be thrown.
      *
-     * @param string $userLogin
-     *            User login name.
-     * @param string $userEmail
-     *            User email address.
-     * @param array $args
-     *            Optional. Extra parameters to pass to WordPress.
+     * @param string $userLogin User login name.
+     * @param string $userEmail User email address.
+     * @param array  $args      Optional. Extra parameters to pass to WordPress.
      *
      * @throws \UnexpectedValueException
      *
      * @return array {
-     *         @type int $id User ID.
-     *         @type string $slug User slug (nicename).
+     *             @type int $id User ID.
+     *             @type string $slug User slug (nicename).
      *         }
      */
     public function createUser($userLogin, $userEmail, $args = [])
@@ -119,7 +116,7 @@ trait UserAwareContextTrait
         }
 
         $return_array = array(
-            'id' => $user->ID,
+            'id'   => $user->ID,
             'slug' => $user->user_nicename
         );
 
@@ -222,8 +219,7 @@ trait UserAwareContextTrait
     /**
      * Get a User's ID from their username.
      *
-     * @param string $username
-     *            The username of the user to get the ID of.
+     * @param string $username The username of the user to get the ID of.
      *
      * @throws \UnexpectedValueException If provided data is invalid
      *
@@ -231,18 +227,14 @@ trait UserAwareContextTrait
      */
     public function getUserIdFromLogin($username)
     {
-        return $this->getDriver()->user->get($username, [
-            'by' => 'login'
-        ])->ID;
+        return $this->getDriver()->user->get($username, ['by' => 'login'])->ID;
     }
 
     /**
      * Delete a user.
      *
-     * @param int $userId
-     *            ID of user to delete.
-     * @param array $args
-     *            Optional. Extra parameters to pass to WordPress.
+     * @param int $userId ID of user to delete.
+     * @param array $args Optional. Extra parameters to pass to WordPress.
      */
     public function deleteUser($userId, $args = [])
     {

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -30,8 +30,8 @@ class UserContext extends RawWordpressContext
             $this->createUser($user['user_login'], $user['user_email'], $user);
 
             // Store new users by username, not by role (unlike what the docs say).
-            $userId = strtolower($user['user_login']);
-            $params['users'][$userId] = array(
+            $user_id = strtolower($user['user_login']);
+            $params['users'][$user_id] = array(
                 'username' => $user['user_login'],
                 'password' => $user['user_pass'],
             );

--- a/src/Driver/Element/Wpcli/DatabaseElement.php
+++ b/src/Driver/Element/Wpcli/DatabaseElement.php
@@ -46,6 +46,15 @@ class DatabaseElement extends BaseElement
     public function update($id, $args = [])
     {
         $this->drivers->getDriver()->wpcli('db', 'import', [$args['path']]);
+
+        /*
+         * The WPPHP driver needs the WP cache flushed at this point. However
+         * WPCLI appears to function without it. This is a note to remind us
+         * so that if we see any strange behaviour with caching which is WPCLI
+         * specific we might catch it. There's a discussion about it here:
+         *
+         * https://github.com/paulgibbs/behat-wordpress-extension/pull/150
+         */
     }
 
 

--- a/src/Driver/Element/Wpcli/UserElement.php
+++ b/src/Driver/Element/Wpcli/UserElement.php
@@ -2,6 +2,7 @@
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;
 use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
 use UnexpectedValueException;
 
@@ -84,6 +85,19 @@ class UserElement extends BaseElement
         }
 
         return $user;
+    }
+
+    /**
+     * Checks that the username and password are correct.
+     *
+     * @param string $username
+     * @param string $password
+     *
+     * @return boolean True if the username and password are correct.
+     */
+    public function validateCredentials(string $username, string $password)
+    {
+        throw new UnsupportedDriverActionException();
     }
 
     /**

--- a/src/Driver/Element/Wpcli/UserElement.php
+++ b/src/Driver/Element/Wpcli/UserElement.php
@@ -97,7 +97,7 @@ class UserElement extends BaseElement
      */
     public function validateCredentials(string $username, string $password)
     {
-        throw new UnsupportedDriverActionException();
+        throw new UnsupportedDriverActionException("No known way to check $username has password $password.");
     }
 
     /**

--- a/src/Driver/Element/Wpphp/DatabaseElement.php
+++ b/src/Driver/Element/Wpphp/DatabaseElement.php
@@ -121,6 +121,9 @@ class DatabaseElement extends BaseElement
                 )
             );
         }
+
+        // clear the cache after restoration
+        \wp_cache_flush();
     }
 
 

--- a/src/Driver/Element/Wpphp/DatabaseElement.php
+++ b/src/Driver/Element/Wpphp/DatabaseElement.php
@@ -122,7 +122,13 @@ class DatabaseElement extends BaseElement
             );
         }
 
-        // clear the cache after restoration
+        /*
+         * clear the cache after restoration - this is probably only necessary
+         * because of some kind of global state issue - the WPCLI driver doensn't
+         * need it. There is some discussion about it here:
+         *
+         * https://github.com/paulgibbs/behat-wordpress-extension/pull/150
+         */
         \wp_cache_flush();
     }
 

--- a/src/Driver/Element/Wpphp/UserElement.php
+++ b/src/Driver/Element/Wpphp/UserElement.php
@@ -58,6 +58,20 @@ class UserElement extends BaseElement
     }
 
     /**
+     * Checks that the username and password are correct.
+     *
+     * @param string $username
+     * @param string $password
+     *
+     * @return boolean True if the username and password are correct.
+     */
+    public function validateCredentials(string $username, string $password)
+    {
+        $check = \wp_authenticate_username_password(null, $username, $password);
+        return !\is_wp_error($check);
+    }
+
+    /**
      * Delete an item for this element.
      *
      * @param int $id Object ID.


### PR DESCRIPTION
This is a fix for #128 in the manner we discussed over there. In summary we now catch the exception which is thrown when a user already exists, grab the existing user, and the check all the parameters match. Unfortunately I've not found a way to validate user credentials using WPCLI as yet - so the password isn't checked. It is checked for WPPHP.