### PR TITLE
Drivers, WP-PHP: remove `get_permalink()` wrapper.

### DIFF
--- a/src/Context/Traits/ContentAwareContextTrait.php
+++ b/src/Context/Traits/ContentAwareContextTrait.php
@@ -22,12 +22,11 @@ trait ContentAwareContextTrait
     public function createContent($args)
     {
         $post = $this->getDriver()->content->create($args);
-        $url  = $this->getDriver()->content->getPermalink($post->ID);
 
         return array(
             'id'   => (int) $post->ID,
             'slug' => $post->post_name,
-            'url'  => $url,
+            'url'  => $post->url,
         );
     }
 
@@ -48,12 +47,11 @@ trait ContentAwareContextTrait
     public function getContentFromTitle($title, $post_type = '')
     {
         $post = $this->getDriver()->content->get($title, ['by' => 'title', 'post_type' => $post_type]);
-        $url = $this->getDriver()->content->getPermalink($post->ID);
 
         return array(
             'id'   => (int) $post->ID,
             'slug' => $post->post_name,
-            'url'  => $url,
+            'url'  => $post->url,
         );
     }
 

--- a/src/Driver/Element/Wpcli/ContentElement.php
+++ b/src/Driver/Element/Wpcli/ContentElement.php
@@ -141,22 +141,6 @@ class ContentElement extends BaseElement
     }
 
     /**
-     * Retrieve the permalink for this post
-     *
-     * @param int $postId the ID of the Post
-     *
-     * @return string $url the permalink
-     */
-    public function getPermalink($postId)
-    {
-        $alt  = $this->drivers->getDriver()->wpcli('post', 'list', ['--post__in=' . $postId, '--fields=url', '--post_type=any', '--format=json'])['stdout'];
-        $alt  = json_decode($alt);
-        $url = $alt[0]->url;
-
-        return $url;
-    }
-
-    /**
      * Delete an item for this element.
      *
      * @param int|string $id   Object ID.

--- a/src/Driver/Element/Wpphp/ContentElement.php
+++ b/src/Driver/Element/Wpphp/ContentElement.php
@@ -68,21 +68,9 @@ class ContentElement extends BaseElement
             throw new UnexpectedValueException(sprintf('Could not find content with ID %d', $id));
         }
 
-        $post->url = $this->getPermalink($post->ID);
+        $post->url = get_permalink($post);
 
         return $post;
-    }
-
-    /**
-     * Retrieve the permalink for this post
-     *
-     * @param int $postId the ID of the Post
-     *
-     * @return string $url the permalink
-     */
-    public function getPermalink($postId)
-    {
-        return \get_permalink($postId);
     }
 
     /**


### PR DESCRIPTION
## Description
Drivers, WP-PHP: remove `get_permalink()` wrapper and pass the post by object, not ID.

## Motivation and context
Performance optimisation and tidy-up of single-use function.

## How has this been tested?
Locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.