### PR TITLE
Move "open the dashboard" step into the Dashboard context.

### DIFF
--- a/src/Context/DashboardContext.php
+++ b/src/Context/DashboardContext.php
@@ -1,7 +1,7 @@
 <?php
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
-use PaulGibbs\WordpressBehatExtension\PageObject\AdminPage;
+use PaulGibbs\WordpressBehatExtension\PageObject\DashboardPage;
 
 /**
  * Provides step definitions that are specific to the WordPress dashboard (wp-admin).
@@ -9,22 +9,40 @@ use PaulGibbs\WordpressBehatExtension\PageObject\AdminPage;
 class DashboardContext extends RawWordpressContext
 {
     /**
-     * Non-specific admin page (wp-admin/) object.
+     * Dashboard page object.
      *
-     * @var AdminPage
+     * @var DashboardPage
      */
     protected $admin_page;
 
     /**
      * Constructor.
      *
-     * @param AdminPage $admin_page AdminPage object.
+     * @param DashboardPage $admin_page
      */
-    public function __construct(AdminPage $admin_page)
+    public function __construct(DashboardPage $admin_page)
     {
         parent::__construct();
 
         $this->admin_page = $admin_page;
+    }
+
+    /**
+     * Open the dashboard.
+     *
+     * Example: Given I am on the dashboard
+     * Example: Given I am in wp-admin
+     * Example: When I go to the dashboard
+     * Example: When I go to wp-admin
+     *
+     * @Given /^(?:I am|they are) on the dashboard/
+     * @Given /^(?:I am|they are) in wp-admin/
+     * @When /^(?:I|they) go to the dashboard/
+     * @When /^(?:I|they) go to wp-admin/
+     */
+    public function iAmOnDashboard()
+    {
+        $this->admin_page->open();
     }
 
     /**

--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -7,7 +7,6 @@ use Behat\Mink\Driver\Selenium2Driver;
 use PaulGibbs\WordpressBehatExtension\Context\Traits\CacheAwareContextTrait;
 use PaulGibbs\WordpressBehatExtension\Context\Traits\DatabaseAwareContextTrait;
 use PaulGibbs\WordpressBehatExtension\Context\Traits\PageObjectAwareContextTrait;
-use PaulGibbs\WordpressBehatExtension\PageObject\DashboardPage;
 
 /**
  * Provides step definitions for a range of common tasks. Recommended for all test suites.
@@ -17,22 +16,11 @@ class WordpressContext extends RawWordpressContext
     use PageObjectAwareContextTrait, CacheAwareContextTrait, DatabaseAwareContextTrait;
 
     /**
-     * Dashboard (wp-admin/index.php) object.
-     *
-     * @var DashboardPage
-     */
-    protected $dashboard;
-
-    /**
      * Constructor.
-     *
-     * @param DashboardPage $dashboard Dashboard object.
      */
-    public function __construct(DashboardPage $dashboard)
+    public function __construct()
     {
         parent::__construct();
-
-        $this->dashboard = $dashboard;
     }
 
     /**
@@ -134,27 +122,5 @@ class WordpressContext extends RawWordpressContext
         }
 
         $this->importDatabase(['path' => $file]);
-    }
-
-    /*
-     * Step definitions lurk beyond.
-     */
-
-    /**
-     * Open the dashboard.
-     *
-     * Example: Given I am on the dashboard
-     * Example: Given I am in wp-admin
-     * Example: When I go to the dashboard
-     * Example: When I go to wp-admin
-     *
-     * @Given /^(?:I am|they are) on the dashboard/
-     * @Given /^(?:I am|they are) in wp-admin/
-     * @When /^(?:I|they) go to the dashboard/
-     * @When /^(?:I|they) go to wp-admin/
-     */
-    public function iAmOnDashboard()
-    {
-        $this->dashboard->open();
     }
 }


### PR DESCRIPTION
`DashboardContext`, also, now receives a `DashboardPage` object rather than a `AdminPage` object.

## Motivation and context
This seems a better location than the common `WordpressContext`.
This again seems a more appropriate object to use rather than the generic `AdminPage` object.

## How has this been tested?
Locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
