### PR TITLE
Use user role instead of name in iAmViewingAuthorArchive context

### DIFF
--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -58,18 +58,25 @@ class UserContext extends RawWordpressContext
     /**
      * Go to a user's author archive page.
      *
-     * Example: Given I am viewing posts published by Admin
-     * Example: When I am viewing posts published by Admin
+     * Example: Given I am viewing posts published by admin
+     * Example: When I am viewing posts published by admin
      *
      * @When I am viewing posts published by :user
      *
-     * @param string $username
+     * @param string $role
      */
-    public function iAmViewingAuthorArchive(string $username)
+    public function iAmViewingAuthorArchive($role)
     {
+        $role  = strtolower($role);
+        $users = $this->getWordpressParameter('users');
+
+        if ($users === null || empty($users[$role])) {
+            throw new RuntimeException("User details for role \"{$role}\" not found.");
+        }
+
         $this->visitPath(sprintf(
             $this->getWordpressParameters()['permalinks']['author_archive'],
-            $this->getUserDataFromUsername('user_nicename', $username)
+            $this->getUserDataFromUsername('user_nicename', $users[$role]['username'])
         ));
     }
 


### PR DESCRIPTION
Fix inconsistency in iAmViewingAuthorArchive context.

## Description
* See https://github.com/paulgibbs/behat-wordpress-extension/issues/183

## Related issue
* https://github.com/paulgibbs/behat-wordpress-extension/issues/183

## Motivation and context
Trying to make tests consistent.

## How has this been tested?
I have run all tests and they are passing, but extra testing may be needed.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. # Not sure where is it
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
