### PR TITLE
Require strict typing throughout.

### DIFF
--- a/src/Compiler/DriverElementPass.php
+++ b/src/Compiler/DriverElementPass.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Compiler/DriverPass.php
+++ b/src/Compiler/DriverPass.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Context/ContentContext.php
+++ b/src/Context/ContentContext.php
@@ -81,8 +81,7 @@ class ContentContext extends RawWordpressContext
     protected function parseArgs(array $post_data): array
     {
         if (isset($post_data['post_author'])) {
-            $user_id = $this->getUserIdFromLogin($post_data['post_author']);
-            $post_data['post_author'] = (int) $user_id;
+            $post_data['post_author'] = $this->getUserIdFromLogin($post_data['post_author']);
         }
 
         return $post_data;

--- a/src/Context/ContentContext.php
+++ b/src/Context/ContentContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use UnexpectedValueException;

--- a/src/Context/ContextClass/ClassGenerator.php
+++ b/src/Context/ContextClass/ClassGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\ContextClass;
 
 use Behat\Behat\Context\ContextClass\ClassGenerator as BehatContextGenerator;

--- a/src/Context/DashboardContext.php
+++ b/src/Context/DashboardContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use PaulGibbs\WordpressBehatExtension\PageObject\DashboardPage;

--- a/src/Context/DebugContext.php
+++ b/src/Context/DebugContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 /**

--- a/src/Context/EditPostContext.php
+++ b/src/Context/EditPostContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use PaulGibbs\WordpressBehatExtension\PageObject\PostsEditPage;

--- a/src/Context/EditPostContext.php
+++ b/src/Context/EditPostContext.php
@@ -122,7 +122,7 @@ class EditPostContext extends RawWordpressContext
     public function iEnterContentIntoPostContentEditor(PyStringNode $content)
     {
         $content_editor = $this->edit_post_page->getContentEditor();
-        $content_editor->setContent($content);
+        $content_editor->setContent($content->getRaw());
     }
 
     /**

--- a/src/Context/Initialiser/WordpressAwareInitialiser.php
+++ b/src/Context/Initialiser/WordpressAwareInitialiser.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Initialiser;
 
 use Behat\Behat\Context\Context;

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use Behat\Behat\Context\SnippetAcceptingContext;

--- a/src/Context/SiteContext.php
+++ b/src/Context/SiteContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 /**

--- a/src/Context/ToolbarContext.php
+++ b/src/Context/ToolbarContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use Behat\Mink\Exception\ElementTextException;

--- a/src/Context/Traits/BaseAwarenessTrait.php
+++ b/src/Context/Traits/BaseAwarenessTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 use PaulGibbs\WordpressBehatExtension\Driver\DriverInterface;

--- a/src/Context/Traits/CacheAwareContextTrait.php
+++ b/src/Context/Traits/CacheAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 /**

--- a/src/Context/Traits/CommentAwareContextTrait.php
+++ b/src/Context/Traits/CommentAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 /**

--- a/src/Context/Traits/ContentAwareContextTrait.php
+++ b/src/Context/Traits/ContentAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 /**

--- a/src/Context/Traits/DatabaseAwareContextTrait.php
+++ b/src/Context/Traits/DatabaseAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 /**

--- a/src/Context/Traits/PluginAwareContextTrait.php
+++ b/src/Context/Traits/PluginAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 /**

--- a/src/Context/Traits/TermAwareContextTrait.php
+++ b/src/Context/Traits/TermAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 /**

--- a/src/Context/Traits/ThemeAwareContextTrait.php
+++ b/src/Context/Traits/ThemeAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 /**

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 use Behat\Mink\Exception\DriverException;

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -238,7 +238,7 @@ trait UserAwareContextTrait
      */
     public function getUserIdFromLogin(string $username): int
     {
-        return $this->getDriver()->user->get($username, ['by' => 'login'])->ID;
+        return (int) $this->getDriver()->user->get($username, ['by' => 'login'])->ID;
     }
 
     /**

--- a/src/Context/Traits/WidgetAwareContextTrait.php
+++ b/src/Context/Traits/WidgetAwareContextTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 
 trait WidgetAwareContextTrait

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use Behat\Gherkin\Node\TableNode;

--- a/src/Context/WidgetContext.php
+++ b/src/Context/WidgetContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use Behat\Gherkin\Node\TableNode;

--- a/src/Context/WordpressAwareInterface.php
+++ b/src/Context/WordpressAwareInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use Behat\Behat\Context\Context;

--- a/src/Context/WordpressContext.php
+++ b/src/Context/WordpressContext.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Context;
 
 use Behat\Behat\Hook\Scope\AfterScenarioScope;

--- a/src/Driver/BaseDriver.php
+++ b/src/Driver/BaseDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver;
 
 use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;

--- a/src/Driver/BlackboxDriver.php
+++ b/src/Driver/BlackboxDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver;
 
 /**

--- a/src/Driver/DriverInterface.php
+++ b/src/Driver/DriverInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver;
 
 /**

--- a/src/Driver/Element/BaseElement.php
+++ b/src/Driver/Element/BaseElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element;
 
 use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;

--- a/src/Driver/Element/ElementInterface.php
+++ b/src/Driver/Element/ElementInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element;
 
 /**

--- a/src/Driver/Element/Wpcli/CacheElement.php
+++ b/src/Driver/Element/Wpcli/CacheElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpcli/CommentElement.php
+++ b/src/Driver/Element/Wpcli/CommentElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpcli/ContentElement.php
+++ b/src/Driver/Element/Wpcli/ContentElement.php
@@ -94,8 +94,8 @@ class ContentElement extends BaseElement
     /**
      * Retrieve an item for this element.
      *
-     * @param int|string $id Object ID.
-     * @param array $args Optional data used to fetch an object.
+     * @param int|string $id   Object ID.
+     * @param array      $args Optional data used to fetch an object.
      *
      * @throws \UnexpectedValueException
      *

--- a/src/Driver/Element/Wpcli/ContentElement.php
+++ b/src/Driver/Element/Wpcli/ContentElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpcli/DatabaseElement.php
+++ b/src/Driver/Element/Wpcli/DatabaseElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use RuntimeException;

--- a/src/Driver/Element/Wpcli/PluginElement.php
+++ b/src/Driver/Element/Wpcli/PluginElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpcli/TermElement.php
+++ b/src/Driver/Element/Wpcli/TermElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use UnexpectedValueException;

--- a/src/Driver/Element/Wpcli/ThemeElement.php
+++ b/src/Driver/Element/Wpcli/ThemeElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpcli/UserElement.php
+++ b/src/Driver/Element/Wpcli/UserElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpcli/WidgetElement.php
+++ b/src/Driver/Element/Wpcli/WidgetElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpphp/CacheElement.php
+++ b/src/Driver/Element/Wpphp/CacheElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpphp/CommentElement.php
+++ b/src/Driver/Element/Wpphp/CommentElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpphp/ContentElement.php
+++ b/src/Driver/Element/Wpphp/ContentElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use WP_Query;

--- a/src/Driver/Element/Wpphp/DatabaseElement.php
+++ b/src/Driver/Element/Wpphp/DatabaseElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use RuntimeException;

--- a/src/Driver/Element/Wpphp/PluginElement.php
+++ b/src/Driver/Element/Wpphp/PluginElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use UnexpectedValueException;

--- a/src/Driver/Element/Wpphp/TermElement.php
+++ b/src/Driver/Element/Wpphp/TermElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpphp/ThemeElement.php
+++ b/src/Driver/Element/Wpphp/ThemeElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpphp/UserElement.php
+++ b/src/Driver/Element/Wpphp/UserElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/Element/Wpphp/WidgetElement.php
+++ b/src/Driver/Element/Wpphp/WidgetElement.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver;
 
 use RuntimeException;

--- a/src/Driver/WpphpDriver.php
+++ b/src/Driver/WpphpDriver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver;
 
 use RuntimeException;

--- a/src/Exception/UnsupportedDriverActionException.php
+++ b/src/Exception/UnsupportedDriverActionException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Exception;
 
 use Exception;

--- a/src/PageObject/AdminPage.php
+++ b/src/PageObject/AdminPage.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\PageObject;
 
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;

--- a/src/PageObject/DashboardPage.php
+++ b/src/PageObject/DashboardPage.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\PageObject;
 
 use Behat\Mink\Exception\ExpectationException;

--- a/src/PageObject/Element/AdminMenu.php
+++ b/src/PageObject/Element/AdminMenu.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
 
 use RuntimeException;

--- a/src/PageObject/Element/PostContentEditor.php
+++ b/src/PageObject/Element/PostContentEditor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
 
 /**

--- a/src/PageObject/Element/TinyMCEEditor.php
+++ b/src/PageObject/Element/TinyMCEEditor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
 
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\PageObject\Element;
 
 use SensioLabs\Behat\PageObjectExtension\PageObject\Element;

--- a/src/PageObject/PostsEditPage.php
+++ b/src/PageObject/PostsEditPage.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\PageObject;
 
 use Behat\Mink\Element\NodeElement;

--- a/src/ServiceContainer/WordpressBehatExtension.php
+++ b/src/ServiceContainer/WordpressBehatExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\ServiceContainer;
 
 use Behat\Behat\Context\ServiceContainer\ContextExtension;

--- a/src/Util/functions.php
+++ b/src/Util/functions.php
@@ -109,7 +109,7 @@ function buildCLIArgs($whitelist, $raw_args)
         if (is_numeric($option)) {
             $retval[] = escapeshellcmd("--{$value}");
         } else {
-            $retval[] = sprintf('--%s=%s', $option, escapeshellarg($value));
+            $retval[] = sprintf('--%s=%s', $option, escapeshellarg((string) $value));
         }
     }
 

--- a/src/Util/functions.php
+++ b/src/Util/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Util;
 
 use Exception;

--- a/src/WordpressDriverManager.php
+++ b/src/WordpressDriverManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension;
 
 use PaulGibbs\WordpressBehatExtension\Driver\DriverInterface;


### PR DESCRIPTION
## Description
Force PHP to use strict types.

This change "proposes the addition of a new optional per-file directive, declare(strict_types=1);, which makes all function calls and return statements within a file have “strict” type-checking for scalar type declarations, including for extension and built-in PHP functions."

This does not mean that every project using WordHat has to use strict types. It does mean that, internally, we can choose to use strict type handling for the core project on a per-file basis.

## Related issue
Follows on from #180 

## Motivation and context
To modernise the PHP, and because I haven't tried to use these with a PHP project before.

## How has this been tested?
Travis-CI.

## Types of changes
Unsure:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.