### PR TITLE
Drivers: set `path` argument as optional.

### DIFF
--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -49,7 +49,7 @@ PaulGibbs\WordpressBehatExtension:
 Option           | Default value | Description
 :----------------| :------------ | :----------
 `default_driver` | "wpcli"       | _Optional_.<br>The [WordPress driver](/features/overview.md) to use ("wpcli", "wpphp").
-`path`           | null          | _Required_.<br>Path to WordPress files.
+`path`           | null          | _Optional_.<br>Path to WordPress files.
 `users.*`        | _see example_ | _Optional_.<br>Keys must match names of WordPress roles.
 `site_url`       | null          | _Optional_.<br>If your WordPress is installed in a subdirectory, set this to the `site_url()` value. Defaults to [`mink.base_url`](http://behat.org/en/latest/user_guide/configuration.html#extensions).
 `permalinks.*`   | _see example_ | _Optional_.<br>Permalink pattern for the specific kind of link.<br>`%s` is replaced with an ID/object name, as appropriate.

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -44,21 +44,16 @@ class WpcliDriver extends BaseDriver
      * Constructor.
      *
      * @param string      $alias  WP-CLI alias. This or $path must be not falsey.
-     * @param string      $path   Path to WordPress site's files. This or $alias must be not falsey.
      * @param string      $url    WordPress site URL.
      * @param string|null $binary Path to the WP-CLI binary.
+     * @param string      $path   Optional. Path to WordPress site's files. This or $alias must be not falsey.
      */
-    public function __construct(string $alias, string $path, string $url, string $binary = null)
+    public function __construct(string $alias, string $url, string $binary = null, string $path = '')
     {
         $this->alias  = ltrim($alias, '@');
-        $this->path   = $path ? realpath($path) : '';
+        $this->path   = $path;
         $this->url    = rtrim(filter_var($url, FILTER_SANITIZE_URL), '/');
         $this->binary = $binary;
-
-        // Path can be relative.
-        if (! $this->path) {
-            $this->path = $path;
-        }
     }
 
     /**
@@ -111,7 +106,11 @@ class WpcliDriver extends BaseDriver
     public function wpcli(string $command, string $subcommand, array $raw_arguments = []): array
     {
         $arguments = implode(' ', $raw_arguments);
-        $config    = sprintf('--path=%s --url=%s', escapeshellarg($this->path), escapeshellarg($this->url));
+        $config    = sprintf('--url=%s', escapeshellarg($this->url));
+
+        if ($this->path) {
+            $config .= sprintf(' --path=%s', escapeshellarg($this->path));
+        }
 
         // Support WP-CLI environment aliases.
         if ($this->alias) {

--- a/src/Driver/WpphpDriver.php
+++ b/src/Driver/WpphpDriver.php
@@ -26,11 +26,11 @@ class WpphpDriver extends BaseDriver
     /**
      * Constructor.
      *
-     * @param string $path Path to WordPress site's files.
+     * @param string $path Optional. Path to WordPress site's files.
      */
-    public function __construct(string $path)
+    public function __construct(string $path = '')
     {
-        $this->path = realpath($path);
+        $this->path = $path;
     }
 
     /**

--- a/src/ServiceContainer/WordpressBehatExtension.php
+++ b/src/ServiceContainer/WordpressBehatExtension.php
@@ -251,10 +251,6 @@ class WordpressBehatExtension implements ExtensionInterface
 
         $loader->load('drivers/wpcli.yml');
 
-        if (empty($config['path']) && empty($config['wpcli']['alias'])) {
-            throw new RuntimeException('WP-CLI driver requires an `alias` or root `path` set.');
-        }
-
         $config['wpcli']['alias'] = isset($config['wpcli']['alias']) ? $config['wpcli']['alias'] : '';
         $container->setParameter('wordpress.driver.wpcli.alias', $config['wpcli']['alias']);
 
@@ -282,10 +278,6 @@ class WordpressBehatExtension implements ExtensionInterface
         }
 
         $loader->load('drivers/wpphp.yml');
-
-        if (empty($config['path'])) {
-            throw new RuntimeException('WordPress PHP driver requires a root `path` set.');
-        }
 
         $config['wpphp']['path'] = isset($config['path']) ? $config['path'] : '';
         $container->setParameter('wordpress.driver.wpphp.path', $config['wpphp']['path']);

--- a/src/ServiceContainer/config/drivers/wpcli.yml
+++ b/src/ServiceContainer/config/drivers/wpcli.yml
@@ -15,9 +15,9 @@ services:
     class: "%wordpress.driver.wpcli.class%"
     arguments:
       - "%wordpress.driver.wpcli.alias%"
-      - "%wordpress.path%"
       - "%mink.base_url%"
       - "%wordpress.driver.wpcli.binary%"
+      - "%wordpress.path%"
     tags:
       - { name: wordpress.driver, alias: wpcli }
 


### PR DESCRIPTION
To facilitate environments where the WordPress path is not known until runtime, and where CLI-over-SSH is used, the `path` argument is now optional.

I am not sure why `path` used to be checked with `realpath()`; it was implemented in the earliest stagest of WordHat's development, and it might not have had a reason that stands up to scrutiny at the current time.

See #185

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
