### PR TITLE
Support for multiple drivers

### DIFF
--- a/docs/recipes/faq.md
+++ b/docs/recipes/faq.md
@@ -8,6 +8,7 @@ If you are new to the project or Behat, we recommend that you first [read throug
 ## Drivers
 * If you are using the WP-CLI driver to [connect to a remote WordPress site over SSH](https://make.wordpress.org/cli/handbook/running-commands-remotely/), WordHat assumes the remote server is Linux-like, with a shell that provides [GNU Coreutils](https://www.gnu.org/software/coreutils/coreutils.html).
 * To configure WordHat to use a specific driver, set [`default_driver`](/configuration/settings.md) in your `behat.yml`.
+* As of v1.1.0, it is possible to use multiple drivers at the same time. This should be considered an experimental feature for advanced users only. To enable it, tag a scenario with the name of the driver to use (e.g. `@wpcli` or `@wpphp`).
 
 ## Browsers
 * If you are using [Selenium](http://docs.seleniumhq.org/download/) to run Javascript tests, and you access your WordPress site over HTTPS, *and* it has a self-signed certificate, you will need to manually configure the web browser to accept that certificate.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,7 @@ pages:
     - Overview: features/overview.md
   - Configuration:
     - Settings: configuration/settings.md
-  - Recipes:
+  - Support:
     - FAQ: recipes/faq.md
     - Database content: recipes/content.md
   - News: changelog.md

--- a/src/Compiler/DriverElementPass.php
+++ b/src/Compiler/DriverElementPass.php
@@ -22,9 +22,7 @@ class DriverElementPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $wordpress = $container->getDefinition('wordpress.wordpress');
-        $driver    = $container->getParameter('wordpress.wordpress.default_driver');
-
-        if (! $wordpress || ! $driver) {
+        if (! $wordpress) {
             return;
         }
 
@@ -34,11 +32,7 @@ class DriverElementPass implements CompilerPassInterface
                     continue;
                 }
 
-                if ($attribute['driver'] !== $driver) {
-                    continue;
-                }
-
-                $wordpress->addMethodCall('registerDriverElement', [$attribute['alias'], new Reference($id)]);
+                $wordpress->addMethodCall('registerDriverElement', [$attribute['alias'], new Reference($id), $attribute['driver']]);
             }
         }
     }

--- a/src/Compiler/DriverElementPass.php
+++ b/src/Compiler/DriverElementPass.php
@@ -32,7 +32,10 @@ class DriverElementPass implements CompilerPassInterface
                     continue;
                 }
 
-                $wordpress->addMethodCall('registerDriverElement', [$attribute['alias'], new Reference($id), $attribute['driver']]);
+                $wordpress->addMethodCall(
+                    'registerDriverElement',
+                    [$attribute['alias'], new Reference($id), $attribute['driver']]
+                );
             }
         }
     }

--- a/src/Compiler/EventSubscriberPass.php
+++ b/src/Compiler/EventSubscriberPass.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+namespace PaulGibbs\WordpressBehatExtension\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Event subscribers pass.
+ *
+ * Register all available event subscribers.
+ */
+class EventSubscriberPass implements CompilerPassInterface
+{
+    /**
+     * Processes container.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (! $container->hasDefinition('wordpress.event_dispatcher')) {
+            return;
+        }
+
+        $dispatcher = $container->getDefinition('wordpress.event_dispatcher');
+
+        foreach ($container->findTaggedServiceIds('wordpress.event_subscriber') as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                $priority = isset($attribute['priority']) ? intval($attribute['priority']) : 0;
+
+                $dispatcher->addMethodCall(
+                    'addSubscriber',
+                    array(new Reference($id), $priority)
+                );
+            }
+        }
+    }
+}

--- a/src/Compiler/EventSubscriberPass.php
+++ b/src/Compiler/EventSubscriberPass.php
@@ -32,7 +32,7 @@ class EventSubscriberPass implements CompilerPassInterface
 
                 $dispatcher->addMethodCall(
                     'addSubscriber',
-                    array(new Reference($id), $priority)
+                    [new Reference($id), $priority]
                 );
             }
         }

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -128,7 +128,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function getDriver(string $name = ''): DriverInterface
     {
-        return $this->getWordpress()->getDriver($name);
+        return $this->getWordpress()->getDriver($name, 'skip bootstrap');
     }
 
     /**

--- a/src/Context/RawWordpressContext.php
+++ b/src/Context/RawWordpressContext.php
@@ -128,7 +128,7 @@ class RawWordpressContext extends RawMinkContext implements WordpressAwareInterf
      */
     public function getDriver(string $name = ''): DriverInterface
     {
-        return $this->getWordpress()->getDriver($name, 'skip bootstrap');
+        return $this->getWordpress()->getDriver($name);
     }
 
     /**

--- a/src/Listener/DriverListener.php
+++ b/src/Listener/DriverListener.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+namespace PaulGibbs\WordpressBehatExtension\Listener;
+
+use Behat\Behat\EventDispatcher\Event\ExampleTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
+use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use PaulGibbs\WordpressBehatExtension\WordpressDriverManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * WordPress driver listener.
+ *
+ * Determines which WordPress driver to use for a given scenario or outline.
+ */
+class DriverListener implements EventSubscriberInterface
+{
+    /**
+     * WordPress driver manager.
+     *
+     * @var WordpressDriverManager
+     */
+    protected $wordpress;
+
+    /**
+     * WordPress context parameters.
+     *
+     * @var array
+     */
+    protected $parameters = [];
+
+    /**
+     * Constructor.
+     *
+     * @param WordpressDriverManager $wordpress
+     * @param array                  $parameters
+     */
+    public function __construct(WordpressDriverManager $wordpress, array $parameters)
+    {
+        $this->wordpress  = $wordpress;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * @return array The event names to listen to.
+     */
+    public static function getSubscribedEvents() : array
+    {
+        return array(
+            ScenarioTested::BEFORE => ['prepareWordpressDriver', 11],  // Scenarios
+            ExampleTested::BEFORE  => ['prepareWordpressDriver', 11],  // Scenario Outlines
+        );
+    }
+
+    /**
+     * Configures the driver to use before each scenario or outline.
+     *
+     * @param ScenarioLikeTested $event
+     */
+    public function prepareWordpressDriver($event)
+    {
+        $drivers = array_keys($this->wordpress->getDrivers());
+        $driver  = $this->parameters['default_driver'];
+        $tags    = array_merge($event->getFeature()->getTags(), $event->getScenario()->getTags());
+
+        // If the scenario or outline is tagged with a specific driver, switch to it.
+        foreach ($tags as $tag) {
+            if (! in_array($tag, $drivers, true)) {
+                continue;
+            }
+
+            $driver = $tag;
+            break;
+        }
+
+        $this->wordpress->setDefaultDriverName($driver);
+    }
+}

--- a/src/ServiceContainer/WordpressBehatExtension.php
+++ b/src/ServiceContainer/WordpressBehatExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 use PaulGibbs\WordpressBehatExtension\Compiler\DriverPass;
 use PaulGibbs\WordpressBehatExtension\Compiler\DriverElementPass;
+use PaulGibbs\WordpressBehatExtension\Compiler\EventSubscriberPass;
 
 use RuntimeException;
 
@@ -318,7 +319,9 @@ class WordpressBehatExtension implements ExtensionInterface
     {
         $this->processDriverPass($container);
         $this->processDriverElementPass($container);
+        $this->processEventSubscriberPass($container);
         $this->processClassGenerator($container);
+
         $this->setPageObjectNamespaces($container);
         $this->injectSiteUrlIntoPageObjects($container);
     }
@@ -343,6 +346,17 @@ class WordpressBehatExtension implements ExtensionInterface
     {
         $driver = new DriverElementPass();
         $driver->process($container);
+    }
+
+    /**
+     * Process the Event Subscriber Pass.
+     *
+     * @param ContainerBuilder $container
+     */
+    private function processEventSubscriberPass(ContainerBuilder $container)
+    {
+        $event = new EventSubscriberPass();
+        $event->process($container);
     }
 
     /**

--- a/src/ServiceContainer/config/services.yml
+++ b/src/ServiceContainer/config/services.yml
@@ -14,3 +14,10 @@ services:
       - "%wordpress.parameters%"
     tags:
       - { name: context.initializer }
+  wordpress.listener.driver:
+    class: 'PaulGibbs\WordpressBehatExtension\Listener\DriverListener'
+    arguments:
+      - "@wordpress.wordpress"
+      - "%wordpress.parameters%"
+    tags:
+      - { name: event_dispatcher.subscriber, priority: 0 }

--- a/src/WordpressDriverManager.php
+++ b/src/WordpressDriverManager.php
@@ -72,28 +72,25 @@ class WordpressDriverManager
      */
     public function registerDriverElement(string $name, ElementInterface $element, string $driver_name)
     {
-        $this->getDriver($driver_name)->registerElement($name, $element);
+        $this->getDriver($driver_name, 'skip bootstrap')->registerElement($name, $element);
     }
 
     /**
      * Return a registered driver by name (defaults to the default driver).
      *
-     * @param string $name Optional. The name of the driver to return. If omitted, the default driver is returned.
+     * @since 1.1.0 Added $bootstrap parameter.
+     *
+     * @param string $name      Optional. The name of the driver to return. If omitted, the default driver is returned.
+     * @param string $bootstrap Optional. If "skip bootstrap", driver bootstrap is skipped. Default: "do bootstrap".
      *
      * @return DriverInterface The requested driver.
      *
      * @throws \InvalidArgumentException
      */
-    public function getDriver(string $name = ''): DriverInterface
+    public function getDriver(string $name = '', string $bootstrap = 'do bootstrap'): DriverInterface
     {
-        $skip_bootstrap = false;
-
-        if ($name) {
-            $skip_bootstrap = true;
-            $name           = strtolower($name);
-        } else {
-            $name           = $this->default_driver;
-        }
+        $do_bootstrap = ($bootstrap === 'do bootstrap');
+        $name         = $name ? strtolower($name) : $this->default_driver;
 
         if (! isset($this->drivers[$name])) {
             throw new InvalidArgumentException("Driver '{$name}' is not registered.");
@@ -102,7 +99,7 @@ class WordpressDriverManager
         $driver = $this->drivers[$name];
 
         // Bootstrap driver if needed.
-        if (! $skip_bootstrap && ! $driver->isBootstrapped()) {
+        if ($do_bootstrap && ! $driver->isBootstrapped()) {
             $driver->bootstrap();
         }
 

--- a/src/WordpressDriverManager.php
+++ b/src/WordpressDriverManager.php
@@ -64,12 +64,15 @@ class WordpressDriverManager
     /**
      * Register a new driver element.
      *
-     * @param string           $name    Driver name.
-     * @param ElementInterface $element An instance of a ElementInterface.
+     * @since 1.1.0 Added $driver_name parameter.
+     *
+     * @param string           $name        Element name.
+     * @param ElementInterface $element     An instance of a ElementInterface.
+     * @param string           $driver_name Driver name.
      */
-    public function registerDriverElement(string $name, ElementInterface $element)
+    public function registerDriverElement(string $name, ElementInterface $element, string $driver_name)
     {
-        $this->getDriver()->registerElement($name, $element);
+        $this->getDriver($driver_name)->registerElement($name, $element);
     }
 
     /**
@@ -83,7 +86,14 @@ class WordpressDriverManager
      */
     public function getDriver(string $name = ''): DriverInterface
     {
-        $name = strtolower($name) ?: $this->default_driver;
+        $skip_bootstrap = false;
+
+        if ($name) {
+            $skip_bootstrap = true;
+            $name           = strtolower($name);
+        } else {
+            $name           = $this->default_driver;
+        }
 
         if (! isset($this->drivers[$name])) {
             throw new InvalidArgumentException("Driver '{$name}' is not registered.");
@@ -92,7 +102,7 @@ class WordpressDriverManager
         $driver = $this->drivers[$name];
 
         // Bootstrap driver if needed.
-        if (! $driver->isBootstrapped()) {
+        if (! $skip_bootstrap && ! $driver->isBootstrapped()) {
             $driver->bootstrap();
         }
 


### PR DESCRIPTION
## Description
Support use of multiple drivers. Why? Why not.

## Related issue
For #189

## Motivation and context
Supports use of multiple drivers concurrently. This is very edge-case at the moment, but there's a lot of implementation we can lift from the Drupal Behat Extension -- which was always the intention -- and it might be helpful in the future if/when we introduce a REST API driver. Or if people build custom drivers. Or other weird edge cases.

## How has this been tested?
Locally.

None of the standard tests have been modified to demonstrate the driver switching because that will be a serious pain to get working on the CI environments. I'm thinking about calling this an "experimental" feature in the docs until such time someone finds a good use case for this, and helps us have confidence in the feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.