### PR TITLE
Drivers: if a failure, print stderror if stdout is empty.

### DIFF
--- a/src/Driver/Element/Wpphp/DatabaseElement.php
+++ b/src/Driver/Element/Wpphp/DatabaseElement.php
@@ -47,19 +47,27 @@ class DatabaseElement extends BaseElement
             "{$bin}mysqldump {$command_args}",
             array(
                 1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
             ),
             $pipes
         );
 
         $stdout = trim(stream_get_contents($pipes[1]));
+        $stderr = trim(stream_get_contents($pipes[2]));
         fclose($pipes[1]);
+        fclose($pipes[2]);
         $exit_code = proc_close($proc);
         putenv('MYSQL_PWD=' . $old_pwd);
+
+        // Sometimes the error message is in stderr.
+        if (! $stdout && $stderr) {
+            $stdout = $stderr;
+        }
 
         if ($exit_code || strpos($stdout, 'Warning: ') === 0 || strpos($stdout, 'Error: ') === 0) {
             throw new RuntimeException(
                 sprintf(
-                    "[W606] Could not export database in method %1\$s(): \n%2\$s\n(%3\$s)",
+                    "[W606] Could not export database in method %1\$s(): \n\n%2\$s.\n(%3\$s)",
                     debug_backtrace()[1]['function'],
                     $stdout,
                     $exit_code
@@ -103,19 +111,27 @@ class DatabaseElement extends BaseElement
             "{$bin}mysql {$command_args}",
             array(
                 1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
             ),
             $pipes
         );
 
         $stdout = trim(stream_get_contents($pipes[1]));
+        $stderr = trim(stream_get_contents($pipes[2]));
         fclose($pipes[1]);
+        fclose($pipes[2]);
         $exit_code = proc_close($proc);
         putenv('MYSQL_PWD=' . $old_pwd);
+
+        // Sometimes the error message is in stderr.
+        if (! $stdout && $stderr) {
+            $stdout = $stderr;
+        }
 
         if ($exit_code || strpos($stdout, 'Warning: ') === 0 || strpos($stdout, 'Error: ') === 0) {
             throw new RuntimeException(
                 sprintf(
-                    "[W607] Could not import database in method %1\$s(): \n%2\$s\n(%3\$s)",
+                    "[W607] Could not import database in method %1\$s(): \n\n%2\$s.\n(%3\$s)",
                     debug_backtrace()[1]['function'],
                     $stdout,
                     $exit_code

--- a/src/Driver/WpcliDriver.php
+++ b/src/Driver/WpcliDriver.php
@@ -124,13 +124,21 @@ class WpcliDriver extends BaseDriver
             $command,
             array(
                 1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
             ),
             $pipes
         );
 
         $stdout = trim(stream_get_contents($pipes[1]));
+        $stderr = trim(stream_get_contents($pipes[2]));
         fclose($pipes[1]);
+        fclose($pipes[2]);
         $exit_code = proc_close($proc);
+
+        // Sometimes the error message is in stderr.
+        if (! $stdout && $stderr) {
+            $stdout = $stderr;
+        }
 
         if ($exit_code || strpos($stdout, 'Warning: ') === 0 || strpos($stdout, 'Error: ') === 0) {
             if ($exit_code === 255 && ! $stdout) {
@@ -139,7 +147,7 @@ class WpcliDriver extends BaseDriver
 
             throw new UnexpectedValueException(
                 sprintf(
-                    "[W102] WP-CLI driver failure in method %1\$s():\n%2\$s.\nTried to run: %3\$s\n(%4\$s)",
+                    "[W102] WP-CLI driver failure in method %1\$s():\n\n%2\$s.\n\nTried to run: %3\$s\n(%4\$s)",
                     debug_backtrace()[1]['function'],
                     $stdout,
                     $command,


### PR DESCRIPTION
## Description
Improves display of error messages, especially for WP-CLI.

## Related issue
#197

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
