### PR TITLE
Context, User: deprecate `validateCredentials` in `UserElement` classes.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,8 @@ description: WordHat project news and changelog
 # News
 
 ## Master branch
-- tbc
+### Changed
+- Deprecate `validateCredentials` in `UserElement` classes for all drivers; add no-op. Methods will be removed in 4.0.0.
 
 ## [3.0.0] - 2018-08-09
 ### Changed

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -158,13 +158,7 @@ trait UserAwareContextTrait
          */
         foreach ($args as $parameter => $value) {
             if ($parameter === 'password') {
-                try {
-                    if (! $this->getDriver()->user->validateCredentials($args['user_login'], $value)) {
-                        throw new UnexpectedValueException('[W804] User with login: ' . $user->user_login . ' exists but password is incorrect');
-                    }
-                } catch (UnsupportedDriverActionException $exception) {
-                    // WPCLI can't do this yet.
-                }
+                continue;
             }
 
             if ($this->isValidUserParameter($parameter) && $user->$parameter !== $args[$parameter]) {
@@ -216,7 +210,6 @@ trait UserAwareContextTrait
             'user_email',
             'user_registered',
             'roles',
-            // 'user_pass', - exclude the password for the moment - need special logic for it
             'user_nicename',
             'user_url',
             'user_activation_key',

--- a/src/Driver/Element/Wpcli/UserElement.php
+++ b/src/Driver/Element/Wpcli/UserElement.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
 
 use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
-use PaulGibbs\WordpressBehatExtension\Exception\UnsupportedDriverActionException;
 use function PaulGibbs\WordpressBehatExtension\Util\buildCLIArgs;
 use UnexpectedValueException;
 
@@ -120,14 +119,17 @@ class UserElement extends BaseElement
     /**
      * Checks that the username and password are correct.
      *
+     * @deprecated 3.1.0 Redundant. Now just a no-op.
+     * @todo Remove in 4.0.0.
+     *
      * @param string $username
      * @param string $password
      *
-     * @return boolean True if the username and password are correct.
+     * @return true
      */
     public function validateCredentials(string $username, string $password)
     {
-        throw new UnsupportedDriverActionException("[W505] No known way to check $username has password $password");
+        return true;
     }
 
     /**

--- a/src/Driver/Element/Wpphp/UserElement.php
+++ b/src/Driver/Element/Wpphp/UserElement.php
@@ -80,15 +80,17 @@ class UserElement extends BaseElement
     /**
      * Checks that the username and password are correct.
      *
+     * @deprecated 3.1.0 Redundant. Now just a no-op.
+     * @todo Remove in 4.0.0.
+     *
      * @param string $username
      * @param string $password
      *
-     * @return boolean True if the username and password are correct.
+     * @return true
      */
     public function validateCredentials(string $username, string $password)
     {
-        $check = \wp_authenticate_username_password(null, $username, $password);
-        return !\is_wp_error($check);
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Description
Remove `validateCredentials` methods in `UserElement` classes. This attempted to compare passwords on user objects.

Methods will be removed in 4.0.0.

## Related issue
See #155

## Motivation and context
I've decided I do not like behaviour that cannot be specific to all drivers, unless there is a strong reason, and I do not think this has it. I have been skeptical of the benefit of trying to compare user passwords in this method, so I am going to rip it out.

## How has this been tested?
Not locally. :D

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.