### PR TITLE
Switch jQuery references with plain Javascript.

### DIFF
--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -119,7 +119,7 @@ class Toolbar extends Element
                 // "Focus" (add hover class) on the toolbar link so the submenu appears.
                 $id = $first_level_item->getAttribute('id');
                 $this->getSession()->evaluateScript(
-                    'document.getElementById("#' . $id . '").classList.add("hover");'
+                    'var el = document.getElementById("#' . $id . '"); if (el) { el.classList.add("hover"); }'
                 );
             } catch (UnsupportedDriverActionException $e) {
                 // This will fail for GoutteDriver but neither is it necessary.
@@ -185,7 +185,7 @@ class Toolbar extends Element
          */
         try {
             $this->getSession()->evaluateScript(
-                'document.getElementById("#wp-admin-bar-my-account").classList.add("hover");'
+                'var el = document.getElementById("#wp-admin-bar-my-account"); if (el) { el.classList.add("hover"); }'
             );
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary.

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -120,7 +120,6 @@ class Toolbar extends Element
                 $id = $first_level_item->getAttribute('id');
                 $this->getSession()->executeScript(
                     '(function(){var el = document.getElementById("#' . $id . '"); if (el) { el.classList.add("hover"); }})()'
-
                 );
             } catch (UnsupportedDriverActionException $e) {
                 // This will fail for GoutteDriver but neither is it necessary.

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -119,7 +119,7 @@ class Toolbar extends Element
                 // "Focus" (add hover class) on the toolbar link so the submenu appears.
                 $id = $first_level_item->getAttribute('id');
                 $this->getSession()->executeScript(
-                    '(function(){var el = document.getElementById("#' . $id . '"); if (el) { el.classList.add("hover"); }})()'
+                    '(function(){var el = document.getElementById("#' . $id . '"); if (el.length) { el.classList.add("hover"); }})()'
                 );
             } catch (UnsupportedDriverActionException $e) {
                 // This will fail for GoutteDriver but neither is it necessary.
@@ -185,7 +185,7 @@ class Toolbar extends Element
          */
         try {
             $this->getSession()->executeScript(
-                '(function(){var el = document.getElementById("#wp-admin-bar-my-account"); if (el) { el.classList.add("hover"); }})()'
+                '(function(){var el = document.getElementById("#wp-admin-bar-my-account"); if (el.length) { el.classList.add("hover"); }})()'
             );
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary.

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -118,8 +118,9 @@ class Toolbar extends Element
             try {
                 // "Focus" (add hover class) on the toolbar link so the submenu appears.
                 $id = $first_level_item->getAttribute('id');
-                $this->getSession()->evaluateScript(
-                    'const el = document.getElementById("#' . $id . '"); if (el) { el.classList.add("hover"); }'
+                $this->getSession()->executeScript(
+                    '(function(){var el = document.getElementById("#' . $id . '"); if (el) { el.classList.add("hover"); }})()'
+
                 );
             } catch (UnsupportedDriverActionException $e) {
                 // This will fail for GoutteDriver but neither is it necessary.
@@ -184,8 +185,8 @@ class Toolbar extends Element
          * See https://github.com/paulgibbs/behat-wordpress-extension/issues/65
          */
         try {
-            $this->getSession()->evaluateScript(
-                'const el = document.getElementById("#wp-admin-bar-my-account"); if (el) { el.classList.add("hover"); }'
+            $this->getSession()->executeScript(
+                '(function(){var el = document.getElementById("#wp-admin-bar-my-account"); if (el) { el.classList.add("hover"); }})()'
             );
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary.

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -119,7 +119,7 @@ class Toolbar extends Element
                 // "Focus" (add hover class) on the toolbar link so the submenu appears.
                 $id = $first_level_item->getAttribute('id');
                 $this->getSession()->evaluateScript(
-                    'var el = document.getElementById("#' . $id . '"); if (el) { el.classList.add("hover"); }'
+                    'const el = document.getElementById("#' . $id . '"); if (el) { el.classList.add("hover"); }'
                 );
             } catch (UnsupportedDriverActionException $e) {
                 // This will fail for GoutteDriver but neither is it necessary.
@@ -185,7 +185,7 @@ class Toolbar extends Element
          */
         try {
             $this->getSession()->evaluateScript(
-                'var el = document.getElementById("#wp-admin-bar-my-account"); if (el) { el.classList.add("hover"); }'
+                'const el = document.getElementById("#wp-admin-bar-my-account"); if (el) { el.classList.add("hover"); }'
             );
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary.

--- a/src/PageObject/Element/Toolbar.php
+++ b/src/PageObject/Element/Toolbar.php
@@ -119,7 +119,7 @@ class Toolbar extends Element
                 // "Focus" (add hover class) on the toolbar link so the submenu appears.
                 $id = $first_level_item->getAttribute('id');
                 $this->getSession()->evaluateScript(
-                    'jQuery("#' . $id . '").addClass("hover");'
+                    'document.getElementById("#' . $id . '").classList.add("hover");'
                 );
             } catch (UnsupportedDriverActionException $e) {
                 // This will fail for GoutteDriver but neither is it necessary.
@@ -185,7 +185,7 @@ class Toolbar extends Element
          */
         try {
             $this->getSession()->evaluateScript(
-                'jQuery("#wp-admin-bar-my-account").addClass("hover");'
+                'document.getElementById("#wp-admin-bar-my-account").classList.add("hover");'
             );
         } catch (UnsupportedDriverActionException $e) {
             // This will fail for GoutteDriver but neither is it necessary.


### PR DESCRIPTION
## Description
We should not assume that the WordPress site is reliant on jQuery.

## Related issue
Fixes #213

## Motivation and context
It fixes WordHat menu bar interaction on sites without jQuery.

## How has this been tested?
Not locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
