### PR TITLE
Add a context for editing the latest post

### DIFF
--- a/src/Context/EditPostContext.php
+++ b/src/Context/EditPostContext.php
@@ -225,4 +225,58 @@ class EditPostContext extends RawWordpressContext
             $this->getSession()->getDriver()
         );
     }
+
+    /**
+     * Go to the edit post admin page for the latest post of a specific post status and post type.
+     *
+     * This step allows you to specify the post type to consider.
+     * This step allows you to specify the post status to consider.
+     *
+     * Example: Given I am editing the latest published post
+     * Example: Given I am editing the latest draft event
+     * Example: Given I am editing the latest scheduled post
+     *
+     * @Given /^I am editing the latest ([a-z_-]+) ([a-z_-]+)$/
+     *
+     * @param string $post_status The post status of the referenced 'post' being edited.
+     * @param string $post_type The post type of the referenced 'post' being edited.
+     */
+    public function iEditTheLatestPostOfPostTypeAndStatus(string $post_status='publish', string $post_type)
+    {
+
+        /**
+         * Removed "ed" from the end of $post_status if it is present.
+         * This allows words like "published" to be translated into the proper post status.
+         */
+        $post_status_ending = substr($post_status, -2);
+        if ( 'ed' == $post_status_ending ) {
+            $post_status = substr($post_status, 0, -2);
+        }
+
+        $args = array (
+            "--post_type=$post_type",
+            '--field=ID',
+            '--orderby=date',
+            '--order=DESC',
+            "--post_status=$post_status",
+            '--posts_per_page=1',
+            '--ignore_sticky_posts=1',
+        );
+        
+        $wpcli_output = $this->getDriver()->wpcli('post', 'list', $args);
+
+        // Throw an exception if the result from wp-cli is empty or is not number.
+        if( 
+            empty( $wpcli_output['stdout'] ) || 
+            1 !== preg_match( '/^[0-9]+$/', $wpcli_output['stdout'] ) 
+        ){
+            throw new \Exception("No posts with the post type '$post_type' and post status '$post_status' found");
+        }
+
+        $post_id = (int) $wpcli_output['stdout'];
+        
+        $this->edit_post_page->open(array(
+            'id' => $post_id,
+        ));
+    }
 }


### PR DESCRIPTION
This context allows for easy verification of new content by editing the latest post of a specific type and status.

I am using the wp-cli driver, specifically the ability to call arbitrary wp-cli commands. In this case, `wp post list`, which allows for `WP_Query` arguments. I am not sure if this can be adapted to use a different method compatible with other drivers.

## Description
<!--- Describe your changes in detail -->

## Related issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and context
I use this context to check that new posts exist after specific previous steps. For example, checking that a new order has the correct information after an e-commerce purchase or checking that a donation exists after a donation form is submitted on the front-end.

## How has this been tested?
I've tested on various post types and statuses.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
