### PR TITLE
Drivers, Content: ignore sticky posts when fetching.

### DIFF
--- a/src/Driver/Element/Wpcli/ContentElement.php
+++ b/src/Driver/Element/Wpcli/ContentElement.php
@@ -107,7 +107,7 @@ class ContentElement extends BaseElement
 
         // Support fetching via arbitrary field.
         if (! is_numeric($id)) {
-            $wpcli_args = ['--fields=ID,url', "--{$args['by']}=" . escapeshellarg($id), '--post_type=any', '--format=json'];
+            $wpcli_args = ['--fields=ID,url', "--{$args['by']}=" . escapeshellarg($id), '--post_type=any', '--format=json', '--ignore_sticky_posts=true'];
             $result     = json_decode($this->drivers->getDriver()->wpcli('post', 'list', $wpcli_args)['stdout']);
 
             if (empty($result)) {

--- a/src/Driver/Element/Wpphp/ContentElement.php
+++ b/src/Driver/Element/Wpphp/ContentElement.php
@@ -52,12 +52,12 @@ class ContentElement extends BaseElement
             $query = new WP_Query();
             $query = $query->query(array(
                 "{$args['by']}"          => $id,
+                'ignore_sticky_posts'    => true,
                 'no_found_rows'          => true,
                 'posts_per_page'         => 1,
                 'suppress_filters'       => false,
                 'update_post_meta_cache' => false,
                 'update_post_term_cache' => false,
-                ''
             ));
 
             if ($query) {


### PR DESCRIPTION
## Description
This prevents the underlying `WP_Query` in WP-PHP driver and WP-CLI itself
returning sticky posts when retriving a post ID by post title, as seen with
the "I am on the edit screen for" step definition.

This does not affect intentionally retrieving sticky posts in this way.

## Related issue
Fixes #218

## How has this been tested?
Tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
