### PR TITLE
Add login page object

### DIFF
--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -214,6 +214,28 @@ trait UserAwareContextTrait
     }
 
     /**
+     * Verify a username is valid without returning any additional user information.
+     *
+     * @param string $username
+     *
+     * @throws \RuntimeException
+     *
+     * @return bool
+     */
+    public function isUserNameValid(string $username)
+    {
+        $users = $this->getWordpressParameter('users');
+
+        foreach ($users as $user) {
+            if ($username === $user['username']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Checks to see if the passed in parameter applies to a user or not.
      *
      * @param string $user_parameter the parameter to be checked.

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -77,6 +77,8 @@ trait UserAwareContextTrait
         $session = $this->getSession();
         if (! $session->isStarted()) {
             $session->start();
+            // If there isn't a session started the user can't be logged in.
+            return false;
         }
 
         // Dashboard URLs can only be accessed if logged in.

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -214,28 +214,6 @@ trait UserAwareContextTrait
     }
 
     /**
-     * Verify a username is valid without returning any additional user information.
-     *
-     * @param string $username
-     *
-     * @throws \RuntimeException
-     *
-     * @return bool
-     */
-    public function isUserNameValid(string $username)
-    {
-        $users = $this->getWordpressParameter('users');
-
-        foreach ($users as $user) {
-            if ($username === $user['username']) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Checks to see if the passed in parameter applies to a user or not.
      *
      * @param string $user_parameter the parameter to be checked.

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -5,7 +5,7 @@ namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
-use PageObject\LoginPage;
+use PaulGibbs\WordpressBehatExtension\PageObject\LoginPage;
 use UnexpectedValueException;
 
 /**

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -49,7 +49,6 @@ trait UserAwareContextTrait
         }
 
         $this->visitPath('wp-login.php?redirect_to=' . urlencode($this->locatePath($redirect_to)));
-        $page = $this->getSession()->getPage();
 
         $this->login_page->setUserName($username);
         $this->login_page->setUserPassword($password);

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -81,7 +81,7 @@ trait UserAwareContextTrait
         }
 
         // Dashboard URLs can only be accessed if logged in.
-        if ( false !== stripos( $session->getCurrentUrl(), 'wp-admin' ) ) {
+        if (false !== stripos($session->getCurrentUrl(), 'wp-admin')) {
             return true;
         }
 
@@ -93,7 +93,7 @@ trait UserAwareContextTrait
             $body_element = $page->find('css', 'body');
 
             // If the page doesn't have a body element the user is not logged in.
-            if( null === $body_element ) {
+            if (null === $body_element) {
                 return false;
             }
 

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -48,10 +48,19 @@ trait UserAwareContextTrait
             $this->logOut();
         }
 
+        // Start a session.
+        $session = $this->getSession();
+
+        // Go to the login form.
         $this->visitPath('wp-login.php?redirect_to=' . urlencode($this->locatePath($redirect_to)));
 
+        // Fill in username.
         $this->login_page->setUserName($username);
+
+        // Fill in password.
         $this->login_page->setUserPassword($password);
+
+        // Submit the login form.
         $this->login_page->submitLoginForm();
 
         if (! $this->loggedIn()) {

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -48,7 +48,7 @@ trait UserAwareContextTrait
             $this->logOut();
         }
 
-        $this->login_page->goToLoginScreen($redirect_to);
+        $this->visitPath('wp-login.php?redirect_to=' . urlencode($this->locatePath($redirect_to)));
         $page = $this->getSession()->getPage();
 
         $this->login_page->setUserName($username);

--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -90,11 +90,6 @@ trait UserAwareContextTrait
             return false;
         }
 
-        // Dashboard URLs can only be accessed if logged in.
-        if (false !== stripos($session->getCurrentUrl(), 'wp-admin')) {
-            return true;
-        }
-
         $page = $session->getPage();
 
         // Look for a selector to determine if the user is logged in.

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -14,6 +14,34 @@ class UserContext extends RawWordpressContext
     use Traits\UserAwareContextTrait, Traits\CacheAwareContextTrait;
 
     /**
+     * Verify a username is valid and get the matching user information.
+     *
+     * @param string $username
+     *
+     * @throws \RuntimeException
+     *
+     * @return array The WordPress user details matching the given username.
+     */
+    protected function getUserByName(string $username)
+    {
+        $found_user = null;
+        $users      = $this->getWordpressParameter('users');
+
+        foreach ($users as $user) {
+            if ($username === $user['username']) {
+                $found_user = $user;
+                break;
+            }
+        }
+
+        if ($found_user === null) {
+            throw new RuntimeException("[W801] User not found for name \"{$username}\"");
+        }
+
+        return $found_user;
+    }
+
+    /**
      * Add specified user accounts.
      *
      * Example: Given there are users:
@@ -70,19 +98,7 @@ class UserContext extends RawWordpressContext
      */
     public function iAmViewingAuthorArchive(string $username)
     {
-        $found_user = null;
-        $users      = $this->getWordpressParameter('users');
-
-        foreach ($users as $user) {
-            if ($username === $user['username']) {
-                $found_user = $user;
-                break;
-            }
-        }
-
-        if ($found_user === null) {
-            throw new RuntimeException("[W801] User not found for name \"{$username}\"");
-        }
+        $found_user = $this->getUserByName($username);
 
         $this->visitPath(sprintf(
             $this->getWordpressParameters()['permalinks']['author_archive'],
@@ -147,19 +163,7 @@ class UserContext extends RawWordpressContext
      */
     public function iAmLoggedInAsUser(string $username)
     {
-        $found_user = null;
-        $users      = $this->getWordpressParameter('users');
-
-        foreach ($users as $user) {
-            if ($username === $user['username']) {
-                $found_user = $user;
-                break;
-            }
-        }
-
-        if ($found_user === null) {
-            throw new RuntimeException("[W801] User not found for name \"{$username}\"");
-        }
+        $found_user = $this->getUserByName($username);
 
         $this->logIn($found_user['username'], $found_user['password']);
     }

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -42,28 +42,6 @@ class UserContext extends RawWordpressContext
     }
 
     /**
-     * Verify a username is valid without returning any additional user information.
-     *
-     * @param string $username
-     *
-     * @throws \RuntimeException
-     *
-     * @return bool
-     */
-    public function isUserNameValid(string $username)
-    {
-        $users = $this->getWordpressParameter('users');
-
-        foreach ($users as $user) {
-            if ($username === $user['username']) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Add specified user accounts.
      *
      * Example: Given there are users:

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -42,6 +42,28 @@ class UserContext extends RawWordpressContext
     }
 
     /**
+     * Verify a username is valid without returning any additional user information.
+     *
+     * @param string $username
+     *
+     * @throws \RuntimeException
+     *
+     * @return bool
+     */
+    public function isUserNameValid(string $username)
+    {
+        $users = $this->getWordpressParameter('users');
+
+        foreach ($users as $user) {
+            if ($username === $user['username']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Add specified user accounts.
      *
      * Example: Given there are users:

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -35,7 +35,7 @@ class LoginPage extends Page
         $url = $session->getCurrentUrl();
 
         // If the login path isn't in the current URL.
-        if (false === strrpos($url, $this->path) ) {
+        if (false === strrpos($url, $this->path)) {
             // We aren't on the login screen.
             throw new ExpectationException(
                 sprintf(
@@ -56,7 +56,7 @@ class LoginPage extends Page
         $login_form = $page->find('css', $login_form_selector);
 
         // If the login form was not found.
-        if ( null === $login_form ) {
+        if (null === $login_form) {
             // We aren't on the login screen.
             throw new ExpectationException(
                 sprintf(
@@ -67,7 +67,6 @@ class LoginPage extends Page
                 $this->getDriver()
             );
         }
-        
     }
     
     /**
@@ -83,7 +82,7 @@ class LoginPage extends Page
         $this->verifyLoginPage();
 
         // Unless username is empty, which will reset the field.
-        if( ! empty( $username ) ) {
+        if (! empty($username)) {
             // Verify the username is valid.
             $found_user = $this->getUserByName($username);
         }
@@ -122,7 +121,7 @@ class LoginPage extends Page
         $username_actual = $user_login_field->getValue();
 
         // Verify the username was filled in correctly.
-        if( $username_actual !== $username ) {
+        if ($username_actual !== $username) {
             throw new ExpectationException(
                 sprintf(
                     'Expected the username field to be "%1$s", found "%2$s".',
@@ -132,7 +131,6 @@ class LoginPage extends Page
                 $this->getDriver()
             );
         }
-
     }
 
     /**
@@ -181,7 +179,7 @@ class LoginPage extends Page
         $password_actual = $user_pass_field->getValue();
 
         // Verify the password was filled in correctly.
-        if( $password_actual !== $password ) {
+        if ($password_actual !== $password) {
             throw new ExpectationException(
                 sprintf(
                     'Expected the password field to be "%1$s", found "%2$s".',
@@ -191,7 +189,6 @@ class LoginPage extends Page
                 $this->getDriver()
             );
         }
-
     }
 
     /**
@@ -203,14 +200,13 @@ class LoginPage extends Page
     {
 
         // Add the redirect to parameter the login path.
-        $login_path = $this->path . '?redirect_to=' . urlencode( $redirect_to );
+        $login_path = $this->path . '?redirect_to=' . urlencode($redirect_to);
 
         // Visit the login path.
-        $this->visitPath( $login_path );
+        $this->visitPath($login_path);
 
         // Verify we are on the login page.
         $this->verifyLoginPage();
-
     }
 
     /**
@@ -236,7 +232,6 @@ class LoginPage extends Page
 
         // Click the submit button.
         $submit_button->click();
-
     }
 
      /**
@@ -244,17 +239,17 @@ class LoginPage extends Page
      *
      * @return Session Mink session.
      */
-    protected function verifySession($session_name=null) {
+    protected function verifySession($session_name = null)
+    {
         // Get the session, by name if one is given.
         $session = ( null === $session_name ) ? $this->getSession() : $this->getSession($session_name);
         
         // Start the session if needed.
-        if ( ! $session->isStarted() ) {
+        if (! $session->isStarted()) {
             $session->start();
         }
 
         // Return the session.
         return $session;
     }
-
 }

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -10,7 +10,7 @@ use Behat\Mink\Exception\ExpectationException;
 /**
  * Page object representing a the WordPress login page.
  *
- * This class houses methods for interacting with the login and login form
+ * This class houses methods for interacting with the login page and login form
  */
 class LoginPage extends Page
 {
@@ -68,28 +68,6 @@ class LoginPage extends Page
             );
         }
     }
-
-    /**
-     * Verify a username is valid without returning any additional user information.
-     *
-     * @param string $username
-     *
-     * @throws \RuntimeException
-     *
-     * @return bool
-     */
-    protected function isUserNameValid(string $username)
-    {
-        $users = $this->getWordpressParameter('users');
-
-        foreach ($users as $user) {
-            if ($username === $user['username']) {
-                return true;
-            }
-        }
-
-        return false;
-    }
     
     /**
      * Fills the user_login field of the login form with a given username.
@@ -102,12 +80,6 @@ class LoginPage extends Page
     {
         // Verify we are on the login page.
         $this->verifyLoginPage();
-
-        // Unless username is empty, which will reset the field.
-        if (! empty($username)) {
-            // Verify the username is valid.
-            $this->isUserNameValid($username);
-        }
 
         // Get the session.
         $session = $this->verifySession();

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -229,11 +229,8 @@ class LoginPage extends Page
             $session->start();
         }
 
-        // Stash the current URL
-        $current_url = $this->getSession->getCurrentUrl();
-
         // If we aren't on a valid page
-        if ('about:blank' === $current_url) {
+        if ('about:blank' === $session->getCurrentUrl()) {
             // Go to the home page
             $session->visit($this->getMinkParameter('base_url'));
         }

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -68,6 +68,28 @@ class LoginPage extends Page
             );
         }
     }
+
+    /**
+     * Verify a username is valid without returning any additional user information.
+     *
+     * @param string $username
+     *
+     * @throws \RuntimeException
+     *
+     * @return bool
+     */
+    protected function isUserNameValid(string $username)
+    {
+        $users = $this->getWordpressParameter('users');
+
+        foreach ($users as $user) {
+            if ($username === $user['username']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
     
     /**
      * Fills the user_login field of the login form with a given username.

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -1,0 +1,260 @@
+<?php
+declare(strict_types=1);
+namespace PaulGibbs\WordpressBehatExtension\PageObject;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * Page object representing a the WordPress login page.
+ *
+ * This class houses methods for interacting with the login and login form
+ */
+class LoginPage extends Page
+{
+    
+    /**
+     * @var string $path
+     */
+    protected $path = 'wp-login.php';
+
+    /**
+     * Asserts the current screen is the login page.
+     *
+     * @throws ExpectationException
+     */
+    protected function verifyLoginPage()
+    {
+
+        // Get the session.
+        $session = $this->verifySession();
+
+        // Get the url.
+        $url = $session->getCurrentUrl();
+
+        // If the login path isn't in the current URL.
+        if (false === strrpos($url, $this->path) ) {
+            // We aren't on the login screen.
+            throw new ExpectationException(
+                sprintf(
+                    'Expected screen is the wp-login form, instead on "%1$s".',
+                    $url
+                ),
+                $this->getDriver()
+            );
+        }
+
+        // Get the page.
+        $page = $session->getPage();
+
+        // Login form CSS selector
+        $login_form_selector = '#loginform';
+
+        // Search for the login form exists.
+        $login_form = $page->find('css', $login_form_selector);
+
+        // If the login form was not found.
+        if ( null === $login_form ) {
+            // We aren't on the login screen.
+            throw new ExpectationException(
+                sprintf(
+                    'Expected to find the login form with the selector "%1$s" at the current URL "%2$s".',
+                    $login_form_selector,
+                    $url
+                ),
+                $this->getDriver()
+            );
+        }
+        
+    }
+    
+    /**
+     * Fills the user_login field of the login form with a given username.
+     *
+     * @param string $username the username to fill into the login form
+     *
+     * @throws \Behat\Mink\Exception\ExpectationException
+     */
+    public function setUserName(string $username)
+    {
+        // Verify we are on the login page.
+        $this->verifyLoginPage();
+
+        // Unless username is empty, which will reset the field.
+        if( ! empty( $username ) ) {
+            // Verify the username is valid.
+            $found_user = $this->getUserByName($username);
+        }
+
+        // Get the session.
+        $session = $this->verifySession();
+
+        // Get the page.
+        $page = $session->getPage();
+
+        // Find the user_login field.
+        $user_login_field = $page->find('css', '#user_login');
+
+        // Try to focus the user_login field.
+        try {
+            $user_login_field->focus();
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for GoutteDriver but neither is it necessary.
+        }
+
+        // Set the value of $username in the user_login field.
+        $user_login_field->setValue($username);
+        // The field can be stubborn, so we use fillField also.
+        $page->fillField('user_login', $username);
+
+        // Attempt to fill the user_login field with JavaScript.
+        try {
+            $session->executeScript(
+                "document.getElementById('user_login').value='$username'"
+            );
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for drivers without JavaScript support
+        }
+
+        // Get the actual value of the user_login field.
+        $username_actual = $user_login_field->getValue();
+
+        // Verify the username was filled in correctly.
+        if( $username_actual !== $username ) {
+            throw new ExpectationException(
+                sprintf(
+                    'Expected the username field to be "%1$s", found "%2$s".',
+                    $username,
+                    $$username_actual
+                ),
+                $this->getDriver()
+            );
+        }
+
+    }
+
+    /**
+     * Fills the user_pass field of the login form with a given password.
+     *
+     * @param string $password the password to fill into the login form
+     *
+     * @throws \Behat\Mink\Exception\ExpectationException
+     */
+    public function setUserPassword(string $username)
+    {
+        // Verify we are on the login page.
+        $this->verifyLoginPage();
+
+        // Get the session.
+        $session = $this->verifySession();
+
+        // Get the page.
+        $page = $session->getPage();
+
+        // Find the user_pass field.
+        $user_pass_field = $page->find('css', '#user_pass');
+
+        // Try to focus the user_pass field.
+        try {
+            $user_pass_field->focus();
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for GoutteDriver but neither is it necessary.
+        }
+
+        // Set the value of $password in the user_pass field.
+        $user_pass_field->setValue($password);
+        // The field can be stubborn, so we use fillField also.
+        $page->fillField('user_pass', $password);
+
+        // Attempt to fill the user_pass field with JavaScript.
+        try {
+            $session->executeScript(
+                "document.getElementById('user_pass').value='$password'"
+            );
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for drivers without JavaScript support
+        }
+
+        // Get the actual value of the user_pass field.
+        $password_actual = $user_pass_field->getValue();
+
+        // Verify the password was filled in correctly.
+        if( $password_actual !== $password ) {
+            throw new ExpectationException(
+                sprintf(
+                    'Expected the password field to be "%1$s", found "%2$s".',
+                    $password,
+                    $$password_actual
+                ),
+                $this->getDriver()
+            );
+        }
+
+    }
+
+    /**
+     * Go to the WordPress login screen
+     *
+     * @param string $redirect_to optional URL for the redirect_to parameter
+     */
+    public function goToLoginScreen(string $redirect_to)
+    {
+
+        // Add the redirect to parameter the login path.
+        $login_path = $this->path . '?redirect_to=' . urlencode( $redirect_to );
+
+        // Visit the login path.
+        $this->visitPath( $login_path );
+
+        // Verify we are on the login page.
+        $this->verifyLoginPage();
+
+    }
+
+    /**
+     * Submit the WordPress login form
+     */
+    public function submitLoginForm()
+    {
+
+        // Verify we are on the login page.
+        $this->verifyLoginPage();
+
+        // Get the session.
+        $session = $this->verifySession();
+
+        // Get the page.
+        $page = $session->getPage();
+
+        // Find the submit button.
+        $submit_button = $page->find('css', '#wp-submit');
+
+        // Focus the submit button.
+        $submit_button->focus();
+
+        // Click the submit button.
+        $submit_button->click();
+
+    }
+
+     /**
+     * Verify a properly started mink session
+     *
+     * @return Session Mink session.
+     */
+    protected function verifySession($session_name=null) {
+        // Get the session, by name if one is given.
+        $session = ( null === $session_name ) ? $this->getSession() : $this->getSession($session_name);
+        
+        // Start the session if needed.
+        if ( ! $session->isStarted() ) {
+            $session->start();
+        }
+
+        // Return the session.
+        return $session;
+    }
+
+}

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -186,33 +186,6 @@ class LoginPage extends Page
     }
 
     /**
-     * Go to the WordPress login screen
-     *
-     * @param string $redirect_to optional URL for the redirect_to parameter
-     */
-    public function goToLoginScreen(string $redirect_to)
-    {
-
-        // Get the site URL
-        $site_url = rtrim($this->getParameter('site_url'), '/') . '/';
-
-        // Construct the login path
-        $login_path = $this->path . '?redirect_to=' . urlencode($redirect_to);
-
-        // Construct the login URL
-        $login_url = $site_url . $login_path;
-
-        // Start a session.
-        $session = $this->verifySession();
-
-        // Visit the login path.
-        $session->visit($login_url);
-
-        // Verify we are on the login page.
-        $this->verifyLoginPage();
-    }
-
-    /**
      * Submit the WordPress login form
      */
     public function submitLoginForm()

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -6,6 +6,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Element;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Exception\ExpectationException;
+use PaulGibbs\WordpressBehatExtension\Context\RawWordpressContext;
 
 /**
  * Page object representing a the WordPress login page.
@@ -232,7 +233,7 @@ class LoginPage extends Page
         // If we aren't on a valid page
         if ('about:blank' === $session->getCurrentUrl()) {
             // Go to the home page
-            $session->visit($this->getMinkParameter('base_url'));
+            $session->visit('/');
         }
 
         // Return the session.

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -235,9 +235,9 @@ class LoginPage extends Page
     }
 
      /**
-     * Verify a properly started mink session
+     * Verify and return a properly started Mink session
      *
-     * @return Session Mink session.
+     * @return \Behat\Mink\Session Mink session.
      */
     protected function verifySession()
     {

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -79,11 +79,12 @@ class LoginPage extends Page
      */
     public function setUserName(string $username)
     {
-        // Verify we are on the login page.
-        $this->verifyLoginPage();
 
         // Get the session.
         $session = $this->verifySession();
+
+        // Verify we are on the login page.
+        $this->verifyLoginPage();
 
         // Get the page.
         $page = $session->getPage();
@@ -137,11 +138,12 @@ class LoginPage extends Page
      */
     public function setUserPassword(string $password)
     {
-        // Verify we are on the login page.
-        $this->verifyLoginPage();
 
         // Get the session.
         $session = $this->verifySession();
+
+        // Verify we are on the login page.
+        $this->verifyLoginPage();
 
         // Get the page.
         $page = $session->getPage();
@@ -192,11 +194,11 @@ class LoginPage extends Page
     public function submitLoginForm()
     {
 
-        // Verify we are on the login page.
-        $this->verifyLoginPage();
-
         // Get the session.
         $session = $this->verifySession();
+
+        // Verify we are on the login page.
+        $this->verifyLoginPage();
 
         // Get the page.
         $page = $session->getPage();

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -229,6 +229,15 @@ class LoginPage extends Page
             $session->start();
         }
 
+        // Stash the current URL
+        $current_url = $this->getSession->getCurrentUrl();
+
+        // If we aren't on a valid page
+        if( 'about:blank' === $current_url ) {
+            // Go to the home page
+            $session->visit($this->getMinkParameter('base_url'));
+        }
+
         // Return the session.
         return $session;
     }

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -193,14 +193,20 @@ class LoginPage extends Page
     public function goToLoginScreen(string $redirect_to)
     {
 
-        // Add the redirect to parameter the login path.
+        // Get the site URL
+        $site_url = rtrim($this->getParameter('site_url'), '/') . '/';
+
+        // Construct the login path
         $login_path = $this->path . '?redirect_to=' . urlencode($redirect_to);
+
+        // Construct the login URL
+        $login_url = $site_url . $login_path;
 
         // Start a session.
         $session = $this->verifySession();
 
         // Visit the login path.
-        $session->visit($this->locatePath($login_path));
+        $session->visit($login_url);
 
         // Verify we are on the login page.
         $this->verifyLoginPage();

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -68,7 +68,7 @@ class LoginPage extends Page
             );
         }
     }
-    
+
     /**
      * Fills the user_login field of the login form with a given username.
      *
@@ -223,7 +223,7 @@ class LoginPage extends Page
     {
         // Get the session.
         $session = $this->getSession();
-        
+
         // Start the session if needed.
         if (! $session->isStarted()) {
             $session->start();

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -14,7 +14,7 @@ use Behat\Mink\Exception\ExpectationException;
  */
 class LoginPage extends Page
 {
-    
+
     /**
      * @var string $path
      */
@@ -84,7 +84,7 @@ class LoginPage extends Page
         // Unless username is empty, which will reset the field.
         if (! empty($username)) {
             // Verify the username is valid.
-            $found_user = $this->getUserByName($username);
+            $this->isUserNameValid($username);
         }
 
         // Get the session.

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -233,7 +233,7 @@ class LoginPage extends Page
         $current_url = $this->getSession->getCurrentUrl();
 
         // If we aren't on a valid page
-        if( 'about:blank' === $current_url ) {
+        if ('about:blank' === $current_url) {
             // Go to the home page
             $session->visit($this->getMinkParameter('base_url'));
         }

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -140,7 +140,7 @@ class LoginPage extends Page
      *
      * @throws \Behat\Mink\Exception\ExpectationException
      */
-    public function setUserPassword(string $username)
+    public function setUserPassword(string $password)
     {
         // Verify we are on the login page.
         $this->verifyLoginPage();

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -230,8 +230,12 @@ class LoginPage extends Page
         // Find the submit button.
         $submit_button = $page->find('css', '#wp-submit');
 
-        // Focus the submit button.
-        $submit_button->focus();
+        // Try to focus the submit button.
+        try {
+            $submit_button->focus();
+        } catch (UnsupportedDriverActionException $e) {
+            // This will fail for GoutteDriver but neither is it necessary.
+        }
 
         // Click the submit button.
         $submit_button->click();

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -239,10 +239,10 @@ class LoginPage extends Page
      *
      * @return Session Mink session.
      */
-    protected function verifySession($session_name = null)
+    protected function verifySession()
     {
-        // Get the session, by name if one is given.
-        $session = ( null === $session_name ) ? $this->getSession() : $this->getSession($session_name);
+        // Get the session.
+        $session = $this->getSession();
         
         // Start the session if needed.
         if (! $session->isStarted()) {

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -200,10 +200,13 @@ class LoginPage extends Page
     {
 
         // Add the redirect to parameter the login path.
-        $login_path = $this->path . '?redirect_to=' . urlencode($redirect_to);
+        $login_path = '/' . $this->path . '?redirect_to=' . urlencode($redirect_to);
+
+        // Start a session.
+        $session = $this->verifySession();
 
         // Visit the login path.
-        $this->visitPath($login_path);
+        $session->visit($login_path);
 
         // Verify we are on the login page.
         $this->verifyLoginPage();

--- a/src/PageObject/LoginPage.php
+++ b/src/PageObject/LoginPage.php
@@ -194,13 +194,13 @@ class LoginPage extends Page
     {
 
         // Add the redirect to parameter the login path.
-        $login_path = '/' . $this->path . '?redirect_to=' . urlencode($redirect_to);
+        $login_path = $this->path . '?redirect_to=' . urlencode($redirect_to);
 
         // Start a session.
         $session = $this->verifySession();
 
         // Visit the login path.
-        $session->visit($login_path);
+        $session->visit($this->locatePath($login_path));
 
         // Verify we are on the login page.
         $this->verifyLoginPage();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add a `LoginPage` `Page` object to interact with the WordPress login page.
* Refactor `UserAwareContextTrait` to use the new `LoginPage` object

## Related issue
Inconsistent user authentication. See [this Slack thread](https://wordhat.slack.com/archives/C472TKN79/p1550278140001300).

## Motivation and context
When writing tests using WordHat I found any scenarios requiring user authentication to be very inconsistent. The tests would fail on one run and pass on the next.

## How has this been tested?
This is an attempt to get my work done in https://github.com/pantheon-systems/example-wordpress-composer/pull/79 merged back upstream in WordHat.

Tests with authentication using these updates, specifically filling fields with JavaScript, have passed with the wp-cli driver locally in a Docker instance, on CircleCI and on GitLab. Previously, the tests would fail intermittently.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
