### PR TITLE
Context, Users: `logOut` can fail if used in first line of step definitions

### DIFF
--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -73,7 +73,11 @@ trait UserAwareContextTrait
      */
     public function logOut()
     {
-        $this->getElement('Toolbar')->logOut();
+        try {
+            $this->getElement('Toolbar')->logOut();
+        } catch (DriverException $e) {
+            // This may fail if the user has not loaded any site yet.
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Catch exception in `logOut()` method.

## Related issue
See #232

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
