### PR TITLE
Context, Users: only log out if the user is currently authenticated.

### DIFF
--- a/src/Context/Traits/UserAwareContextTrait.php
+++ b/src/Context/Traits/UserAwareContextTrait.php
@@ -73,6 +73,10 @@ trait UserAwareContextTrait
      */
     public function logOut()
     {
+        if (! $this->loggedIn()) {
+            return;
+        }
+
         try {
             $this->getElement('Toolbar')->logOut();
         } catch (DriverException $e) {


### PR DESCRIPTION
A further fix at stopping log-out related exceptions and errors when
"I am an anonymous user" is used early in a feature test.

