### PR TITLE
Adds  'page_template' as a whitelisted CLI arg

### DIFF
--- a/src/Driver/Element/Wpcli/ContentElement.php
+++ b/src/Driver/Element/Wpcli/ContentElement.php
@@ -50,7 +50,7 @@ class ContentElement extends BaseElement
                 'ID', 'post_author', 'post_date', 'post_date_gmt', 'post_content', 'post_content_filtered', 'post_title',
                 'post_excerpt', 'post_status', 'post_type', 'comment_status', 'ping_status', 'post_password', 'post_name',
                 'to_ping', 'pinged', 'post_modified', 'post_modified_gmt', 'post_parent', 'menu_order', 'post_mime_type',
-                'guid', 'post_category',
+                'guid', 'post_category', 'page_template',
             ),
             $args
         );


### PR DESCRIPTION
## Description
Adds  `page_template` as a whitelisted CLI argument.

This is an additional field needed that appears to work as one of the extra `--<field>=<value>` entries from https://developer.wordpress.org/cli/commands/post/create/ 

## Related issue
https://github.com/paulgibbs/behat-wordpress-extension/issues/239

## Motivation and context
This change allows setting Page Template via WP CLI.

## How has this been tested?
Only locally, and I am very new to WordHat.

## Screenshots (if appropriate):

```
wp --url='https://myproject.local' 
  --path='/vagrant/wp' 
  --no-color post create 
  --porcelain 
  --post_author='1' 
  --post_name='projects' 
  --post_title='Projects Page' 
  --post_content='Let'\''s make these cool projects' 
  --post_status='publish' 
  --page_template='page-templates/project-home.php' 
  --guid='https://myproject.local/test/5cac9581d3b947.63382717'
  --post_type='page'

Array
(
[0] => --porcelain
[1] => --post_author='1'
[2] => --post_name='projects'
[3] => --post_title='Projects Page'
[4] => --post_content='Let'\''s make these cool projects'
[5] => --post_status='publish'
[6] => --page_template='page-templates/project-home.php'
[7] => --guid='https://myproject.local/test/5cac9581d3b947.63382717'
[8] => --post_type='page'
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
