### PR TITLE
Fix usage of an undefined variable when attempting to create users with the wpphp driver

### DIFF
--- a/src/Driver/Element/Wpphp/UserElement.php
+++ b/src/Driver/Element/Wpphp/UserElement.php
@@ -47,7 +47,7 @@ class UserElement extends BaseElement
             $wp_user->add_role($role);
         }
 
-        return $this->get($user);
+        return $this->get($user_id);
     }
 
     /**


### PR DESCRIPTION
## Description

When using the `wpphp` driver, creating users triggers an error because the `UserElement::create()` method doesn't pass the correct variable to its `get()` method after creating the user.

This fixes that.