### PR TITLE
Bump minimum PHP requirements from 7.1 to 7.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/---report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/---report-a-bug.md
@@ -27,7 +27,7 @@ about: Is something not working as you expected?
 > Include as many relevant details about the environment you experienced the bug in:
 
 * WordHat version used:
-* Environment name and version (e.g. PHP 7.1 on nginx 1.11.9):
+* Environment name and version (e.g. PHP 7.2 on nginx 1.11.9):
 * Server operating system type and version:
 * Type of Behat browser used (e.g. Selenium, headless Chrome, etc):
 * Link to your project:

--- a/.github/ISSUE_TEMPLATE/---request-a-feature.md
+++ b/.github/ISSUE_TEMPLATE/---request-a-feature.md
@@ -17,7 +17,7 @@ about: Do you want to suggest a new feature, rule, or option?
 > Include as many relevant details about the environment you experienced the bug in:
 
 * WordHat version used:
-* Environment name and version (e.g. PHP 7.1 on nginx 1.11.9):
+* Environment name and version (e.g. PHP 7.2 on nginx 1.11.9):
 * Server operating system type and version:
 * Type of Behat browser used (e.g. Selenium, headless Chrome, etc):
 * Link to your project:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - mysql
 
 php:
-  - 7.1
+  - 7.2
   - 7.3
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,7 @@
     "behat/behat": "~3.1",
     "php": ">=7.2 <7.4",
     "sensiolabs/behat-page-object-extension": "~2.1",
-    "behat/mink-extension": "~2.3",
-
-    "ocramius/proxy-manager": "~2.1.0"
+    "behat/mink-extension": "~2.3"
   },
   "require-dev": {
     "behat/mink-goutte-driver": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "require": {
     "behat/behat": "~3.1",
-    "php": ">=7.1 <7.4",
+    "php": ">=7.2 <7.4",
     "sensiolabs/behat-page-object-extension": "~2.1",
     "behat/mink-extension": "~2.3",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49fb09e83c62eb06de203760f4d3fde7",
+    "content-hash": "7b3426545e067f70f052f8d55218bdde",
     "packages": [
         {
             "name": "behat/behat",
@@ -387,33 +387,34 @@
         },
         {
             "name": "ocramius/proxy-manager",
-            "version": "2.1.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7"
+                "reference": "14b137b06b0f911944132df9d51e445a35920ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
-                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/14b137b06b0f911944132df9d51e445a35920ab1",
+                "reference": "14b137b06b0f911944132df9d51e445a35920ab1",
                 "shasum": ""
             },
             "require": {
-                "ocramius/package-versions": "^1.1.1",
-                "php": "^7.1.0",
-                "zendframework/zend-code": "^3.1.0"
+                "ocramius/package-versions": "^1.1.3",
+                "php": "^7.2.0",
+                "zendframework/zend-code": "^3.3.0"
             },
             "require-dev": {
-                "couscous/couscous": "^1.5.2",
+                "couscous/couscous": "^1.6.1",
                 "ext-phar": "*",
-                "humbug/humbug": "dev-master@DEV",
-                "nikic/php-parser": "^3.0.4",
+                "humbug/humbug": "1.0.0-RC.0@RC",
+                "nikic/php-parser": "^3.1.1",
+                "padraic/phpunit-accelerator": "dev-master@DEV",
                 "phpbench/phpbench": "^0.12.2",
-                "phpstan/phpstan": "^0.6.4",
-                "phpunit/phpunit": "^5.6.4",
-                "phpunit/phpunit-mock-objects": "^3.4.1",
-                "squizlabs/php_codesniffer": "^2.7.0"
+                "phpstan/phpstan": "dev-master#856eb10a81c1d27c701a83f167dc870fd8f4236a as 0.9.999",
+                "phpstan/phpstan-phpunit": "dev-master#5629c0a1f4a9c417cb1077cf6693ad9753895761",
+                "phpunit/phpunit": "^6.4.3",
+                "squizlabs/php_codesniffer": "^2.9.1"
             },
             "suggest": {
                 "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
@@ -452,7 +453,7 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2017-05-04T11:12:50+00:00"
+            "time": "2018-09-27T13:45:01+00:00"
         },
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "500d5530511aaa8c06bbd732a92aa11f",
+    "content-hash": "49fb09e83c62eb06de203760f4d3fde7",
     "packages": [
         {
             "name": "behat/behat",
@@ -1114,7 +1114,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -3088,7 +3088,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
+            "description": "? Nette Finder: find files and directories with an intuitive API.",
             "homepage": "https://nette.org",
             "keywords": [
                 "filesystem",
@@ -3148,7 +3148,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "description": "? Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",
@@ -6135,7 +6135,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1 <7.4"
+        "php": ">=7.2 <7.4"
     },
     "platform-dev": []
 }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@ description: How to get install Behat, WordPress, and WordHat
 
 ## Requirements
 
-WordHat requires [PHP](https://php.net/) (version 7.1+), [Composer](https://getcomposer.org/), and a [WordPress](https://wordpress.org/) site to test (version 4.8+).
+WordHat requires [PHP](https://php.net/) (version 7.2+), [Composer](https://getcomposer.org/), and a [WordPress](https://wordpress.org/) site to test (version 4.8+).
 
 We recommend using [WP-CLI](https://wp-cli.org/)[^1] \(version 2.1.0+).
 


### PR DESCRIPTION
## Description
Bump minimum PHP requirements from 7.1 to 7.2

## Related issue
#256

## How has this been tested?
On CI only as I am not aware of any backwards incompatible changes in the WordHat codebase for a PHP 7.1 to 7.2 migration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.