### PR TITLE
Database: add support to delete generated database dumps after-scenario.

### DIFF
--- a/src/Context/Traits/FilesystemAwareContextTrait.php
+++ b/src/Context/Traits/FilesystemAwareContextTrait.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+namespace PaulGibbs\WordpressBehatExtension\Context\Traits;
+
+/**
+ * Provides driver agnostic logic (helper methods) relating to a filesystem or files.
+ */
+trait FilesystemAwareContextTrait
+{
+    use BaseAwarenessTrait;
+
+    /**
+     * Delete specified file.
+     *
+     * @param string $abspath Absolute path to a file, to delete.
+     */
+    public function deleteFile(string $abspath)
+    {
+        $this->getDriver()->filesystem->deleteFile($abspath);
+    }
+}

--- a/src/Driver/Element/Wpcli/FilesystemElement.php
+++ b/src/Driver/Element/Wpcli/FilesystemElement.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli;
+
+use RuntimeException;
+use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+
+/**
+ * WP-CLI driver element for manipulating the filesystem.
+ */
+class FilesystemElement extends BaseElement
+{
+    /**
+     * Delete specified file.
+     *
+     * @param string $abspath Absolute path to a file, to delete.
+     */
+    public function deleteFile(string $abspath)
+    {
+        if (empty($abspath)) {
+            return;
+        }
+
+        $delete_cmd = sprintf('@unlink(%s);', escapeshellarg($abspath));
+        $this->drivers->getDriver()->wpcli('eval', $delete_cmd, ['--skip-wordpress']);
+    }
+}
+

--- a/src/Driver/Element/Wpphp/FilesystemElement.php
+++ b/src/Driver/Element/Wpphp/FilesystemElement.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+namespace PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp;
+
+use RuntimeException;
+use PaulGibbs\WordpressBehatExtension\Driver\Element\BaseElement;
+
+/**
+ * WP-API driver element for manipulating the filesystem.
+ */
+class FilesystemElement extends BaseElement
+{
+    /**
+     * Delete specified file.
+     *
+     * @param string $abspath Absolute path to a file, to delete.
+     */
+    public function deleteFile(string $abspath)
+    {
+        if (empty($abspath) || ! is_file($abspath) || ! is_readable($abspath)) {
+            return;
+        }
+
+        wp_delete_file($abspath);
+    }
+}

--- a/src/ServiceContainer/config/drivers/wpcli.yml
+++ b/src/ServiceContainer/config/drivers/wpcli.yml
@@ -4,6 +4,7 @@ parameters:
   wordpress.element.wpcli.comment.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\CommentElement
   wordpress.element.wpcli.content.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\ContentElement
   wordpress.element.wpcli.database.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\DatabaseElement
+  wordpress.element.wpcli.filesystem.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\FilesystemElement
   wordpress.element.wpcli.plugin.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\PluginElement
   wordpress.element.wpcli.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\TermElement
   wordpress.element.wpcli.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpcli\ThemeElement
@@ -48,6 +49,13 @@ services:
       - "@wordpress.wordpress"
     tags:
       - { name: wordpress.element, alias: database, driver: wpcli }
+
+  wordpress.element.wpcli.filesystem:
+    class: "%wordpress.element.wpcli.filesystem.class%"
+    arguments:
+      - "@wordpress.wordpress"
+    tags:
+      - { name: wordpress.element, alias: filesystem, driver: wpcli }
 
   wordpress.element.wpcli.plugin:
     class: "%wordpress.element.wpcli.plugin.class%"

--- a/src/ServiceContainer/config/drivers/wpphp.yml
+++ b/src/ServiceContainer/config/drivers/wpphp.yml
@@ -4,6 +4,7 @@ parameters:
   wordpress.element.wpphp.comment.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\CommentElement
   wordpress.element.wpphp.content.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\ContentElement
   wordpress.element.wpphp.database.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\DatabaseElement
+  wordpress.element.wpphp.filesystem.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\FilesystemElement
   wordpress.element.wpphp.plugin.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\PluginElement
   wordpress.element.wpphp.term.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\TermElement
   wordpress.element.wpphp.theme.class: PaulGibbs\WordpressBehatExtension\Driver\Element\Wpphp\ThemeElement
@@ -45,6 +46,13 @@ services:
       - "@wordpress.wordpress"
     tags:
       - { name: wordpress.element, alias: database, driver: wpphp }
+
+  wordpress.element.wpphp.filesystem:
+    class: "%wordpress.element.wpphp.filesystem.class%"
+    arguments:
+      - "@wordpress.wordpress"
+    tags:
+      - { name: wordpress.element, alias: filesystem, driver: wpphp }
 
   wordpress.element.wpphp.plugin:
     class: "%wordpress.element.wpphp.plugin.class%"


### PR DESCRIPTION
## Description
If WordHat is configured to generate a DB dump during its run, WordHat was leaving alot of files littering up PHP's temporary folder.

## Related issue
See #227
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and context
Every megabyte counts.
<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?
Locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
